### PR TITLE
Introduce AuthzResult type and return from is_authorized

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ pip install /path/to/cedar-py/target/wheels/cedarpolicy-0.1.0-cp39-cp39-macosx_1
 Then you can use the library from your Python project just like the [tests](tests/unit) demonstrate:
 
 ```python
-import cedarpolicy
+from cedarpolicy import is_authorized, AuthzResult, Decision
 
 policies: str = "//a string containing cedar policies"
 entities: list = [ # a list of Cedar entities; can also be a json-formatted string of Cedar entities
@@ -122,7 +122,7 @@ request = {
     "context": {}
 }
 
-authz_resp: dict = cedarpolicy.is_authorized(request, policies, entities)
+authz_result: AuthzResult = is_authorized(request, policies, entities)
 # The response dict will look like:
 #     {
 #        "decision": "Allow",       # Allow or Deny
@@ -136,7 +136,7 @@ authz_resp: dict = cedarpolicy.is_authorized(request, policies, entities)
 #    }
 
 # so you can assert on the decision like:
-assert "Allow" == authz_resp['decision']
+assert Decision.Allow == authz_result.decision
 ```
 
 ## Contributing

--- a/cedarpolicy/__init__.py
+++ b/cedarpolicy/__init__.py
@@ -1,6 +1,7 @@
 import json
 from copy import copy
-from typing import Union, List
+from enum import Enum
+from typing import Union, List, Any
 
 from cedarpolicy import _cedarpolicy
 
@@ -58,3 +59,24 @@ def is_authorized(request: dict,
 
     authz_response = _cedarpolicy.is_authorized(request, policies, entities, schema, verbose)
     return json.loads(authz_response)
+
+
+class Decision(Enum):
+    Allow = 'Allow'
+    Deny = 'Deny'
+    NoDecision = 'NoDecision'
+
+
+class AuthzResult:
+    def __init__(self, authz_resp: dict) -> None:
+        super().__init__()
+        self._authz_resp = authz_resp
+
+    @property
+    def decision(self) -> Decision:
+        return Decision[self._authz_resp['decision']]
+
+    @property
+    def allowed(self) -> bool:
+        return Decision.Allow == self.decision
+

--- a/cedarpolicy/__init__.py
+++ b/cedarpolicy/__init__.py
@@ -100,5 +100,9 @@ class AuthzResult:
     def diagnostics(self) -> Diagnostics:
         return Diagnostics(self._authz_resp['diagnostics'])
 
+    @property
+    def metrics(self) -> dict:
+        return self._authz_resp.get('metrics', {})
+
     def __getitem__(self, __name: str) -> Any:
         return getattr(self, __name)

--- a/cedarpolicy/__init__.py
+++ b/cedarpolicy/__init__.py
@@ -80,3 +80,5 @@ class AuthzResult:
     def allowed(self) -> bool:
         return Decision.Allow == self.decision
 
+    def __getitem__(self, __name: str) -> Any:
+        return getattr(self, __name)

--- a/cedarpolicy/__init__.py
+++ b/cedarpolicy/__init__.py
@@ -10,11 +10,59 @@ def echo(s: str) -> str:
     return _cedarpolicy.echo(s)
 
 
+class Decision(Enum):
+    Allow = 'Allow'
+    Deny = 'Deny'
+    NoDecision = 'NoDecision'
+
+
+class Diagnostics:
+
+    def __init__(self, diagnostics: dict) -> None:
+        super().__init__()
+        self._diagnostics: dict = diagnostics
+
+    @property
+    def errors(self) -> List[str]:
+        return self._diagnostics.get('errors', list())
+
+    @property
+    def reasons(self) -> List[str]:
+        # (intentionally) map 'reason' key in diagnostics dict to 'reasons' property (plural)
+        return self._diagnostics.get('reason', list())
+
+
+class AuthzResult:
+    def __init__(self, authz_resp: dict) -> None:
+        super().__init__()
+        self._authz_resp = authz_resp
+        self._diagnostics = Diagnostics(self._authz_resp.get('diagnostics', {}))
+
+    @property
+    def decision(self) -> Decision:
+        return Decision[self._authz_resp['decision']]
+
+    @property
+    def allowed(self) -> bool:
+        return Decision.Allow == self.decision
+
+    @property
+    def diagnostics(self) -> Diagnostics:
+        return self._diagnostics
+
+    @property
+    def metrics(self) -> dict:
+        return self._authz_resp.get('metrics', {})
+
+    def __getitem__(self, __name: str) -> Any:
+        return getattr(self, __name)
+
+
 def is_authorized(request: dict,
                   policies: str,
                   entities: Union[str, List[dict]],
                   schema: Union[str, dict, None] = None,
-                  verbose: bool = False) -> dict:
+                  verbose: bool = False) -> AuthzResult:
     """Evaluate whether the request is authorized given the parameters.
 
     :param request is a Cedar-style request object containing a principal, action, resource, and (optional) context;
@@ -58,52 +106,4 @@ def is_authorized(request: dict,
             schema = json.dumps(schema)
 
     authz_response = _cedarpolicy.is_authorized(request, policies, entities, schema, verbose)
-    return json.loads(authz_response)
-
-
-class Decision(Enum):
-    Allow = 'Allow'
-    Deny = 'Deny'
-    NoDecision = 'NoDecision'
-
-
-class Diagnostics:
-
-    def __init__(self, diagnostics: dict) -> None:
-        super().__init__()
-        self._diagnostics: dict = diagnostics
-
-    @property
-    def errors(self) -> List[str]:
-        return self._diagnostics.get('errors', list())
-
-    @property
-    def reasons(self) -> List[str]:
-        # (intentionally) map 'reason' key in diagnostics dict to 'reasons' property (plural)
-        return self._diagnostics.get('reason', list())
-    
-
-class AuthzResult:
-    def __init__(self, authz_resp: dict) -> None:
-        super().__init__()
-        self._authz_resp = authz_resp
-        self._diagnostics = Diagnostics(self._authz_resp.get('diagnostics', {}))
-
-    @property
-    def decision(self) -> Decision:
-        return Decision[self._authz_resp['decision']]
-
-    @property
-    def allowed(self) -> bool:
-        return Decision.Allow == self.decision
-
-    @property
-    def diagnostics(self) -> Diagnostics:
-        return self._diagnostics
-
-    @property
-    def metrics(self) -> dict:
-        return self._authz_resp.get('metrics', {})
-
-    def __getitem__(self, __name: str) -> Any:
-        return getattr(self, __name)
+    return AuthzResult(json.loads(authz_response))

--- a/cedarpolicy/__init__.py
+++ b/cedarpolicy/__init__.py
@@ -87,6 +87,7 @@ class AuthzResult:
     def __init__(self, authz_resp: dict) -> None:
         super().__init__()
         self._authz_resp = authz_resp
+        self._diagnostics = Diagnostics(self._authz_resp.get('diagnostics', {}))
 
     @property
     def decision(self) -> Decision:
@@ -98,7 +99,7 @@ class AuthzResult:
 
     @property
     def diagnostics(self) -> Diagnostics:
-        return Diagnostics(self._authz_resp['diagnostics'])
+        return self._diagnostics
 
     @property
     def metrics(self) -> dict:

--- a/cedarpolicy/__init__.py
+++ b/cedarpolicy/__init__.py
@@ -67,6 +67,22 @@ class Decision(Enum):
     NoDecision = 'NoDecision'
 
 
+class Diagnostics:
+
+    def __init__(self, diagnostics: dict) -> None:
+        super().__init__()
+        self._diagnostics: dict = diagnostics
+
+    @property
+    def errors(self) -> List[str]:
+        return self._diagnostics.get('errors', list())
+
+    @property
+    def reasons(self) -> List[str]:
+        # (intentionally) map 'reason' key in diagnostics dict to 'reasons' property (plural)
+        return self._diagnostics.get('reason', list())
+    
+
 class AuthzResult:
     def __init__(self, authz_resp: dict) -> None:
         super().__init__()
@@ -79,6 +95,10 @@ class AuthzResult:
     @property
     def allowed(self) -> bool:
         return Decision.Allow == self.decision
+
+    @property
+    def diagnostics(self) -> Diagnostics:
+        return Diagnostics(self._authz_resp['diagnostics'])
 
     def __getitem__(self, __name: str) -> Any:
         return getattr(self, __name)

--- a/tests/unit/test_domain.py
+++ b/tests/unit/test_domain.py
@@ -30,9 +30,9 @@ class AuthzResultTestCase(unittest.TestCase):
 
     def test_decision_property_when_Allow(self):
         authz_result = AuthzResult(self.allow_authz_resp)
-        # print(f'authz_result ({type(authz_result)}): {authz_result}')
         self.assertEqual(Decision.Allow, authz_result.decision)
-        self.assertEqual(Decision.Allow, authz_result['decision'])
+        self.assertEqual(Decision.Allow, authz_result['decision'],
+                         msg="decision should be available via subscript")
         self.assertTrue(authz_result.allowed)
 
     def test_decision_property_when_Deny(self):
@@ -77,6 +77,18 @@ class AuthzResultTestCase(unittest.TestCase):
                                  authz_result.metrics)
             else:
                 self.assertEqual({}, authz_result.metrics)
+
+    def test__getitem__makes_properties_subscriptable(self):
+        for authz_resp in [
+            self.allow_authz_resp,
+            self.deny_authz_resp,
+        ]:
+            authz_result = AuthzResult(authz_resp)
+            
+            self.assertEqual(authz_result.decision, authz_result['decision'])
+            self.assertEqual(authz_result.allowed, authz_result['allowed'])
+            self.assertEqual(authz_result.diagnostics, authz_result['diagnostics'])
+            self.assertEqual(authz_result.metrics, authz_result['metrics'])
 
 
 class DiagnosticsTestCase(unittest.TestCase):

--- a/tests/unit/test_domain.py
+++ b/tests/unit/test_domain.py
@@ -1,0 +1,43 @@
+import unittest
+
+from cedarpolicy import AuthzResult, Decision
+
+
+class AuthzResultTestCase(unittest.TestCase):
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.allow_authz_resp = {
+            "decision": "Allow",
+            "diagnostics": {
+                "reason": ["policy0"],
+                "errors": []
+            },
+            "metrics": {"authz_duration_micros": 42}
+        }
+
+        self.deny_authz_resp = {
+            'decision': 'Deny',
+            'diagnostics': {
+                'errors': ['while evaluating policy policy2, encountered the '
+                           'following error: record does not have the '
+                           'required attribute: authenticated'],
+                'reason': []
+            },
+            "metrics": {"authz_duration_micros": 99}
+        }
+
+    def test_decision_property_when_Allow(self):
+        authz_result = AuthzResult(self.allow_authz_resp)
+        # print(f'authz_result ({type(authz_result)}): {authz_result}')
+        self.assertEqual(Decision.Allow, authz_result.decision)
+        # self.assertEqual(Decision.Allow, authz_result['decision'])
+        self.assertTrue(authz_result.allowed)
+
+    def test_decision_property_when_Deny(self):
+        authz_result = AuthzResult(self.deny_authz_resp)
+        self.assertEqual(authz_result.decision, Decision.Deny)
+        # self.assertEqual(Decision.Deny, authz_result['decision'])
+        self.assertFalse(authz_result.allowed)
+

--- a/tests/unit/test_domain.py
+++ b/tests/unit/test_domain.py
@@ -32,12 +32,12 @@ class AuthzResultTestCase(unittest.TestCase):
         authz_result = AuthzResult(self.allow_authz_resp)
         # print(f'authz_result ({type(authz_result)}): {authz_result}')
         self.assertEqual(Decision.Allow, authz_result.decision)
-        # self.assertEqual(Decision.Allow, authz_result['decision'])
+        self.assertEqual(Decision.Allow, authz_result['decision'])
         self.assertTrue(authz_result.allowed)
 
     def test_decision_property_when_Deny(self):
         authz_result = AuthzResult(self.deny_authz_resp)
         self.assertEqual(authz_result.decision, Decision.Deny)
-        # self.assertEqual(Decision.Deny, authz_result['decision'])
+        self.assertEqual(Decision.Deny, authz_result['decision'])
         self.assertFalse(authz_result.allowed)
 

--- a/tests/unit/test_domain.py
+++ b/tests/unit/test_domain.py
@@ -57,6 +57,27 @@ class AuthzResultTestCase(unittest.TestCase):
                              f"expected 'reason' key (singular) to be mapped to reasons property (plural)"
                              f"; authz_resp: {authz_resp}")
 
+    def test_metrics_are_available(self):
+        missing_metrics = {}
+        empty_metrics = {
+            "metrics": {}  # empty metrics
+        }
+        for authz_resp in [
+            self.allow_authz_resp,
+            self.deny_authz_resp,
+            empty_metrics,
+            missing_metrics,
+        ]:
+            authz_result = AuthzResult(authz_resp)
+            self.assertIsNotNone(authz_result.metrics,
+                                 msg=f"metrics were none for {authz_resp}")
+
+            if 'metrics' in authz_resp:
+                self.assertEqual(authz_resp['metrics'],
+                                 authz_result.metrics)
+            else:
+                self.assertEqual({}, authz_result.metrics)
+
 
 class DiagnosticsTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Introduce the `AuthzResult` type and return it from `is_authorized`.  The main idea behind this change is to make it easy to determine the evaluation decision correctly.

Instead of inspecting a dictionary with code like:
```
# old
authz_resp: dict = is_authorized(...)
if "Allow" == authz_resp['decision']:
    ...
```

you can now evaluate the decision with some type safety and navigation support:
```
authz_result: AuthzResult = is_authorized(...)

# check result's decision property against the Decision enum
if Decision.Allow == authz_result.decision
   ...

# or... use the allowed convenience property:
if authz_result.allowed

```
There are similar properties exposing the result's diagnostics and metrics.

## And one more thing: Subscripting
The `AuthzResult` class is subscriptable, so you can also navigate the properties that way, e.g. `authz_result['decision']`.  That provides some Mapping-like compatibility.