### PR TITLE
Add format_policies to pretty-print Cedar policies

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,9 +43,11 @@ jobs:
       - name: pytest
         if: ${{ startsWith(matrix.target, 'x86_64') }}
         shell: bash
+        # disabling the PyPI index on `pip install cedarpy` to ensure we
+        # install cedarpy from the local folder
         run: |
           set -e
-          pip install cedarpy --find-links dist --force-reinstall
+          pip install cedarpy --no-index --find-links dist --force-reinstall
           pip install pytest
           pytest
       - name: pytest
@@ -59,9 +61,11 @@ jobs:
             apt-get update
             apt-get install -y --no-install-recommends python3 python3-pip
             pip3 install -U pip pytest
+          # disabling the PyPI index on `pip install cedarpy` to ensure we
+          # install cedarpy from the local folder
           run: |
             set -e
-            pip3 install cedarpy --find-links dist --force-reinstall
+            pip3 install cedarpy --no-index --find-links dist --force-reinstall
             pytest
 
   windows:
@@ -89,9 +93,11 @@ jobs:
       - name: pytest
         if: ${{ !startsWith(matrix.target, 'aarch64') }}
         shell: bash
+        # disabling the PyPI index on `pip install cedarpy` to ensure we
+        # install cedarpy from the local folder
         run: |
           set -e
-          pip install cedarpy --find-links dist --force-reinstall
+          pip install cedarpy --no-index --find-links dist --force-reinstall
           pip install pytest
           pytest
 
@@ -119,9 +125,11 @@ jobs:
       - name: pytest
         if: ${{ !startsWith(matrix.target, 'aarch64') }}
         shell: bash
+        # disabling the PyPI index on `pip install cedarpy` to ensure we
+        # install cedarpy from the local folder
         run: |
           set -e
-          pip install cedarpy --find-links dist --force-reinstall
+          pip install cedarpy --no-index --find-links dist --force-reinstall
           pip install pytest
           pytest
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,34 @@ assert authz_result['allowed']
 
 ```
 
+### Formatting Cedar policies
+
+You can use `format_policies` to pretty-print Cedar policies according to
+convention.
+
+```python
+from cedarpy import format_policies
+
+policies: str = """
+    permit(
+        principal,
+        action == Action::"edit",
+        resource
+    )
+    when {
+        resource.owner == principal
+    };
+"""
+
+print(format_policies(policies))
+# permit (
+#   principal,
+#   action == Action::"edit",
+#   resource
+# )
+# when { resource.owner == principal };
+```
+
 ## Contributing
 
 This project is very early stage. This project uses GitHub [issues](https://github.com/k9securityio/cedar-py/issues). Contributions are welcome.

--- a/cedarpy/__init__.py
+++ b/cedarpy/__init__.py
@@ -97,3 +97,17 @@ def is_authorized(request: dict,
 
     authz_response = _internal.is_authorized(request, policies, entities, schema, verbose)
     return AuthzResult(json.loads(authz_response))
+
+def format_policies(policies: str,
+                    line_width: int = 80,
+                    indent_width: int = 2) -> str:
+    """Format the provided policies according to the Cedar conventions.
+
+    :param policies is a str containing the policies to be formatted
+    :param line_width (optional) is the desired maximum line length
+    :param indent_width (optional) is the desired indentation width
+
+    :returns the formatted policy
+    :raises ValueError: if the input policies cannot be parsed
+    """
+    return _internal.format_policies(policies, line_width, indent_width)

--- a/tests/unit/test_format_policy.py
+++ b/tests/unit/test_format_policy.py
@@ -1,0 +1,52 @@
+import unittest
+
+from textwrap import dedent
+
+from cedarpy import format_policies
+
+class FormatPolicyTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+    def test_policy_gets_formatted(self):
+        input_policy = dedent("""
+            permit(
+                principal,
+                action == Action::"edit",
+                resource
+            )
+            when {
+                resource.owner == principal
+            };
+        """).strip()
+
+        expect_result = dedent("""
+            permit (
+              principal,
+              action == Action::"edit",
+              resource
+            )
+            when { resource.owner == principal };
+        """).strip()
+
+        actual_result = format_policies(input_policy, indent_width=2)
+
+        self.assertEqual(expect_result, actual_result)
+
+    def test_policy_formatting_error(self):
+        input_policy = dedent("""
+            invalid(
+                principal,
+                action == Action::"edit",
+                resource
+            )
+            when {
+                resource.owner == principal
+            };
+        """).strip()
+
+        try:
+            format_policies(input_policy, indent_width=2)
+            self.fail("should have failed to parse")
+        except ValueError as e:
+            pass


### PR DESCRIPTION
Based on the [CLI](https://github.com/cedar-policy/cedar/blob/217d8c31df6a6eda95bfc218d41c9176a3379f88/cedar-policy-cli/src/lib.rs#L435) implementation.

Fixes #4.