### PR TITLE
Instrument is_authorized to understand where execution time is going

### DIFF
--- a/tests/unit/test_authorize.py
+++ b/tests/unit/test_authorize.py
@@ -205,7 +205,14 @@ class AuthorizeTestCase(unittest.TestCase):
             self.assertIsNotNone(diagnostics.reasons)
 
             self.assertIsNotNone('metrics', actual_authz_result)
-            self.assertIn('authz_duration_micros', actual_authz_result['metrics'])
+            for metric_name in [
+                'total_duration_micros',
+                'parse_policies_duration_micros',
+                'parse_schema_duration_micros',
+                'load_entities_duration_micros',
+                'authz_duration_micros',
+            ]:
+                self.assertIn(metric_name, actual_authz_result['metrics'])
 
     def test_authorize_basic_perf(self):
         import timeit

--- a/tests/unit/test_authorize.py
+++ b/tests/unit/test_authorize.py
@@ -205,6 +205,8 @@ class AuthorizeTestCase(unittest.TestCase):
             self.assertIsNotNone(diagnostics.reasons)
 
             self.assertIsNotNone('metrics', actual_authz_result)
+
+            metrics = actual_authz_result['metrics']
             for metric_name in [
                 'total_duration_micros',
                 'parse_policies_duration_micros',
@@ -212,7 +214,9 @@ class AuthorizeTestCase(unittest.TestCase):
                 'load_entities_duration_micros',
                 'authz_duration_micros',
             ]:
-                self.assertIn(metric_name, actual_authz_result['metrics'])
+                self.assertIn(metric_name, metrics)
+                if 'duration' in metric_name:
+                    self.assertGreaterEqual(metrics[metric_name], 0)
 
     def test_authorize_basic_perf(self):
         import timeit


### PR DESCRIPTION
* parsing policies
* parsing schema
* loading entities
* evaluating access w/ authorizer (already existed)
* total duration

Addresses issue #14 

Produces a metrics object in the authz result that looks like:
```python
{
 'decision': '',
  #... snip ...
  
  'metrics': {
    'total_duration_micros': 923,
    'parse_policies_duration_micros': 625,
    'parse_schema_duration_micros': 0,  
    'load_entities_duration_micros': 212,
    'authz_duration_micros': 23, 
    }
}
```