### PR TITLE
feat: Add is_authorized_batch

### DIFF
--- a/cedarpy/__init__.py
+++ b/cedarpy/__init__.py
@@ -83,6 +83,9 @@ def is_authorized(request: dict,
             context_json_str = json.dumps(context)
             request = copy(request)
             request["context"] = context_json_str
+        elif context is None:
+            request = copy(request)
+            del request["context"]
 
     if isinstance(entities, str):
         pass
@@ -126,6 +129,10 @@ def is_batch_authorized(requests: List[dict],
                 context_json_str = json.dumps(context)
                 request = copy(request)
                 request["context"] = context_json_str
+            elif context is None:
+                request = copy(request)
+                del request["context"]
+
         requests_local.append(request)
 
     if isinstance(entities, str):

--- a/cedarpy/__init__.py
+++ b/cedarpy/__init__.py
@@ -147,23 +147,17 @@ def is_authorized_batch(requests: List[dict],
         elif isinstance(schema, dict):
             schema = json.dumps(schema)
 
-    batch_authz_response_strs: List[str] = _internal.is_authorized_batch(requests_local, policies, entities, schema, verbose)
-    print(f'batch_authz_response_strs: {batch_authz_response_strs}')
-    batch_authz_response_objs: List[dict] = []
+    authz_result_strs: List[str] = _internal.is_authorized_batch(requests_local, policies, entities, schema, verbose)
+    authz_result_objs: List[dict] = []
 
-    for item in batch_authz_response_strs:
-        print(f'item: {type(item)}: {item}')
-        try:
-            batch_authz_response_objs.append(json.loads(item))
-        except Exception as e:
-            pass
+    for authz_result_str in authz_result_strs:
+        authz_result_objs.append(json.loads(authz_result_str))
         
-    batch_authz_responses: List[AuthzResult] = []
-    for response_obj in batch_authz_response_objs:
-        print(f'response_obj: {response_obj}')
-        batch_authz_responses.append(AuthzResult(response_obj))
+    authz_results: List[AuthzResult] = []
+    for response_obj in authz_result_objs:
+        authz_results.append(AuthzResult(response_obj))
 
-    return batch_authz_responses
+    return authz_results
 
 
 def format_policies(policies: str,

--- a/cedarpy/__init__.py
+++ b/cedarpy/__init__.py
@@ -139,12 +139,20 @@ def is_batch_authorized(requests: List[dict],
         elif isinstance(schema, dict):
             schema = json.dumps(schema)
 
-    batch_authz_response_str: str = _internal.is_batch_authorized(requests_local, policies, entities, schema, verbose)
-    batch_authz_response_objs: List[dict] = json.loads(batch_authz_response_str)
+    batch_authz_response_strs: List[str] = _internal.is_batch_authorized(requests_local, policies, entities, schema, verbose)
+    print(f'batch_authz_response_strs: {batch_authz_response_strs}')
+    batch_authz_response_objs: List[dict] = []
 
+    for item in batch_authz_response_strs:
+        try:
+            batch_authz_response_objs.append(json.loads(item))
+        except Exception as e:
+            pass
+        
     batch_authz_responses: List[AuthzResult] = []
-    for o in batch_authz_response_objs:
-        batch_authz_responses.append(AuthzResult(o))
+    for response_obj in batch_authz_response_objs:
+        print(f'response_obj: {response_obj}')
+        batch_authz_responses.append(AuthzResult(response_obj))
 
     return batch_authz_responses
 

--- a/cedarpy/__init__.py
+++ b/cedarpy/__init__.py
@@ -152,6 +152,7 @@ def is_authorized_batch(requests: List[dict],
     batch_authz_response_objs: List[dict] = []
 
     for item in batch_authz_response_strs:
+        print(f'item: {type(item)}: {item}')
         try:
             batch_authz_response_objs.append(json.loads(item))
         except Exception as e:

--- a/cedarpy/__init__.py
+++ b/cedarpy/__init__.py
@@ -76,30 +76,11 @@ def is_authorized(request: dict,
     :returns an AuthzResult
 
     """
-    if "context" in request:
-        context = request["context"]
-        if isinstance(context, dict):
-            # ok user provided context as a dictionary, lets flatten it for them
-            context_json_str = json.dumps(context)
-            request = copy(request)
-            request["context"] = context_json_str
-        elif context is None:
-            request = copy(request)
-            del request["context"]
-
-    if isinstance(entities, str):
-        pass
-    elif isinstance(entities, list):
-        entities = json.dumps(entities)
-
-    if schema is not None:
-        if isinstance(schema, str):
-            pass
-        elif isinstance(schema, dict):
-            schema = json.dumps(schema)
-
-    authz_response = _internal.is_authorized(request, policies, entities, schema, verbose)
-    return AuthzResult(json.loads(authz_response))
+    return is_authorized_batch(requests=[request],
+                               policies=policies,
+                               entities=entities,
+                               schema=schema,
+                               verbose=verbose)[0]
 
 
 def is_authorized_batch(requests: List[dict],

--- a/cedarpy/__init__.py
+++ b/cedarpy/__init__.py
@@ -102,12 +102,13 @@ def is_authorized(request: dict,
     return AuthzResult(json.loads(authz_response))
 
 
-def is_batch_authorized(requests: List[dict],
+def is_authorized_batch(requests: List[dict],
                         policies: str,
                         entities: Union[str, List[dict]],
                         schema: Union[str, dict, None] = None,
                         verbose: bool = False) -> List[AuthzResult]:
-    """Evaluate whether the batch of requests are authorized given the parameters.
+    """Evaluate whether a batch of requests are authorized given the other parameters.  Each request is evaluated
+    independently and results in an AuthzResult per request.
 
     :param requests is list of Cedar-style request objects containing a principal, action, resource, and (optional) context;
     context may be a dict (preferred) or a string
@@ -146,7 +147,7 @@ def is_batch_authorized(requests: List[dict],
         elif isinstance(schema, dict):
             schema = json.dumps(schema)
 
-    batch_authz_response_strs: List[str] = _internal.is_batch_authorized(requests_local, policies, entities, schema, verbose)
+    batch_authz_response_strs: List[str] = _internal.is_authorized_batch(requests_local, policies, entities, schema, verbose)
     print(f'batch_authz_response_strs: {batch_authz_response_strs}')
     batch_authz_response_objs: List[dict] = []
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,8 +111,6 @@ fn is_batch_authorized(requests: Vec<HashMap<String, String>>,
     }
     let mut parse_errs: Vec<ParseErrors> = vec![];
     let mut errs: Vec<Error> = vec![];
-    let t_total = Instant::now();
-
 
     // probably need to deconstruct execute_authorization_request so that we can reuse the
     // expensive parts (policies, entities, schema):
@@ -138,10 +136,6 @@ fn is_batch_authorized(requests: Vec<HashMap<String, String>>,
     let t_load_entities_duration = t_load_entities.elapsed();
 
     // build a list of RequestArgs
-    // evaluate access one at a time (future work: eval in parallel)
-
-
-    // build a vector of RequestArgs with e.g. requests.iter().map()
     let mut request_args_vec: Vec<RequestArgs> = Vec::new();
     requests.iter().for_each(|request: &HashMap<String, String>| {
         request_args_vec.push(to_request_args(request));
@@ -149,8 +143,8 @@ fn is_batch_authorized(requests: Vec<HashMap<String, String>>,
 
     let mut responses_vec: Vec<String> = Vec::new();
 
+    // evaluate access one at a time (future work: eval in parallel)
     for request_args in request_args_vec.iter() {
-        // println!("> {}", request_args);
         let ans = execute_authorization_request(&request_args,
                                                 &policy_set,
                                                 &entities,
@@ -185,8 +179,6 @@ fn is_batch_authorized(requests: Vec<HashMap<String, String>>,
 
         responses_vec.push(response_string);
     }
-
-
 
     return responses_vec;
 }
@@ -255,6 +247,7 @@ fn execute_authorization_request(
     let mut errs: Vec<Error> = vec![];
     let t_total = Instant::now();
 
+    // may want to create request in calling method; then we could get relocate errs
     let request = match request.get_request(schema.as_ref()) {
         Ok(q) => Some(q),
         Err(e) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@ use anyhow::{Context as _, Error, Result};
 use cedar_policy::*;
 use cedar_policy_formatter::{Config, policies_str_to_pretty};
 use pyo3::prelude::*;
-use pyo3::types::{IntoPyDict, PyDict, PyList, PyString};
 use serde::{Deserialize, Serialize};
 
 /// Echo (return) the input string
@@ -201,15 +200,6 @@ fn to_request_args(request: &HashMap<String, String>) -> RequestArgs {
         resource: Some(resource),
         context_json: context_json_option,
     }
-}
-
-fn to_pyerr<E: ToString>(errs: &Vec<E>) -> PyErr {
-    let mut err_str = "Errors: ".to_string();
-    for err in errs.iter() {
-        err_str.push_str(" ");
-        err_str.push_str(&err.to_string());
-    }
-    pyo3::exceptions::PyValueError::new_err(err_str)
 }
 
 /// Authorization response returned from the `Authorizer`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@ fn is_batch_authorized(requests: Vec<HashMap<String, String>>,
 
     // load entities
     let t_load_entities = Instant::now();
-    let entities = make_entities(entities, &&schema, &mut errs);
+    let entities = make_entities(entities, &schema, &mut errs);
     let t_load_entities_duration = t_load_entities.elapsed();
 
     // build a list of RequestArgs
@@ -264,7 +264,7 @@ fn execute_authorization_request(
     }
 }
 
-fn make_entities(entities_str: String, schema: &&Option<Schema>, errs: &mut Vec<Error>) -> Entities {
+fn make_entities(entities_str: String, schema: &Option<Schema>, errs: &mut Vec<Error>) -> Entities {
     let entities = match load_entities(entities_str, schema.as_ref()) {
         Ok(entities) => entities,
         Err(e) => {
@@ -274,7 +274,7 @@ fn make_entities(entities_str: String, schema: &&Option<Schema>, errs: &mut Vec<
     };
     // load actions from the schema and append into entities
     // we could/may integrate this into the load_entities match
-    let entities = match load_actions_from_schema(entities, &schema) {
+    let entities = match load_actions_from_schema(entities, schema) {
         Ok(entities) => entities,
         Err(e) => {
             errs.push(e);
@@ -323,7 +323,7 @@ fn load_actions_from_schema(entities: Entities, schema: &Option<Schema>) -> Resu
                     .cloned()
                     .chain(action_entities.iter().cloned()),
             )
-            .context("failed to merge action entities with entity file"),
+            .context("failed to merge action entities into Entities"),
             Err(e) => Err(e).context("failed to construct action entities"),
         },
         None => Ok(entities),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,18 +201,17 @@ fn is_batch_authorized(requests: Vec<HashMap<String, String>>, //a: Vec<HashMap<
                 match to_json_str_result {
                     Ok(json_str) => { json_str }
                     Err(err) => {
-                        err.to_string()
+                        println!("{:#}", err);
                         //Err(to_pyerr(&Vec::from([err])))
+                        r#"{"errors": ["{}"]}"#.to_string()
                     }
                 }
             }
             Err(errs) => {
-                let err_string: String = String::from("Errors: ");
                 for err in &errs {
                     println!("{:#}", err);
                 }
-                err_string
-                // Err(to_pyerr(&errs))
+                r#"{"errors": ["{}"]}"#.to_string()
             }
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,12 +89,12 @@ fn is_authorized(request: HashMap<String, String>,
                  schema: Option<String>,
                  verbose: Option<bool>)
                  -> String {
-    is_batch_authorized(vec![request], policies, entities, schema, verbose)[0].clone()
+    is_authorized_batch(vec![request], policies, entities, schema, verbose)[0].clone()
 }
 
 #[pyfunction]
 #[pyo3(signature = (requests, policies, entities, schema = None, verbose = false,))]
-fn is_batch_authorized(requests: Vec<HashMap<String, String>>,
+fn is_authorized_batch(requests: Vec<HashMap<String, String>>,
                        policies: String,
                        entities: String,
                        schema: Option<String>,
@@ -336,7 +336,7 @@ fn load_actions_from_schema(entities: Entities, schema: &Option<Schema>) -> Resu
 fn _internal(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(echo, m)?)?;
     m.add_function(wrap_pyfunction!(is_authorized, m)?)?;
-    m.add_function(wrap_pyfunction!(is_batch_authorized, m)?)?;
+    m.add_function(wrap_pyfunction!(is_authorized_batch, m)?)?;
     m.add_function(wrap_pyfunction!(format_policies, m)?)?;
     Ok(())
 }

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,3 +1,4 @@
+import datetime
 from typing import Union
 
 
@@ -11,3 +12,10 @@ def load_file_as_str(relative_file_path: str) -> str:
     import shared
     return shared.load_file_as_str(relative_file_path=relative_file_path,
                                    base_file=__file__)
+
+
+def utc_now() -> datetime.datetime:
+    """
+    Get the current time in UTC.
+    """
+    return datetime.datetime.now(datetime.timezone.utc)

--- a/tests/unit/test_authorize.py
+++ b/tests/unit/test_authorize.py
@@ -409,6 +409,25 @@ class AuthorizeTestCase(unittest.TestCase):
             self.assert_authz_responses_equal(expect_authz_result, actual_authz_result,
                                               ignore_metric_values=True)
 
+    def test_is_authorized_with_a_request_that_errors(self):
+        policies = self.policies["alice"]
+        entities = load_file_as_str("resources/sandbox_b/entities.json")
+        schema = load_file_as_str("resources/sandbox_b/schema.json")
+
+        request = {
+            "principal": 'User::"alice"',
+            "action": 'Action::"addPhoto"',
+            "resource": 'Photo::"alice_w2.jpg"',
+            "context": json.dumps({
+                "authenticated": False
+            })
+        }
+
+        authz_result: AuthzResult = is_authorized(request, policies, entities, schema=schema)
+        self.assertEqual(Decision.NoDecision, authz_result.decision)
+        self.assertEqual(["failed to parse schema from request"],
+                         authz_result.diagnostics.errors)
+
     def test_authorized_batch_perf(self):
         policies = self.policies["alice"]
         entities = load_file_as_str("resources/sandbox_b/entities.json")
@@ -425,7 +444,7 @@ class AuthorizeTestCase(unittest.TestCase):
             'Action::"delete"',
             'Action::"listAlbums"',
             'Action::"listPhotos"',
-            # 'Action::"addPhoto"',
+            'Action::"addPhoto"',
         ]
         
         for action in actions:

--- a/tests/unit/test_authorize.py
+++ b/tests/unit/test_authorize.py
@@ -376,12 +376,14 @@ class AuthorizeTestCase(unittest.TestCase):
         expect_authz_results: List[AuthzResult] = []
 
         t_single_start = utc_now()
-        for action in [
+        actions = [
             'Action::"view"',
             'Action::"edit"',
             'Action::"comment"',
             'Action::"delete"',
-        ]:
+        ]
+        random.shuffle(actions)
+        for action in actions:
             request = {
                 "principal": 'User::"alice"',
                 "action": action,

--- a/tests/unit/test_authorize.py
+++ b/tests/unit/test_authorize.py
@@ -487,11 +487,15 @@ class AuthorizeTestCase(unittest.TestCase):
 
         t_batch_elapsed: timedelta = utc_now() - t_batch_start
 
-        print(f'num_requests: {len(requests)}')
+        num_requests = len(requests)
+        print(f'num_requests: {num_requests}')
         print(f't_single_elapsed:\t{t_single_elapsed.total_seconds()}')
         print(f't_batch_elapsed:\t{t_batch_elapsed.total_seconds()}')
 
-        self.assertLessEqual(t_batch_elapsed, t_single_elapsed)
+        self.assertGreaterEqual(num_requests, 5,
+                                msg=f"should eval batch perf with at least 5 requests")
+        self.assertLessEqual(t_batch_elapsed, (t_single_elapsed / 3),
+                             msg=f"expected batch eval to be +3x faster; check for perf regression")
 
         # verify batch results match single authz
         for expect_authz_result, actual_authz_result in zip(expect_authz_results, actual_authz_results):

--- a/tests/unit/test_authorize.py
+++ b/tests/unit/test_authorize.py
@@ -4,7 +4,7 @@ import unittest
 from datetime import timedelta
 from typing import List, Union
 
-from cedarpy import is_authorized, AuthzResult, Decision, is_batch_authorized
+from cedarpy import is_authorized, AuthzResult, Decision, is_authorized_batch
 
 from unit import load_file_as_str, utc_now
 
@@ -399,7 +399,7 @@ class AuthorizeTestCase(unittest.TestCase):
         t_single_elapsed: timedelta = utc_now() - t_single_start
 
         t_batch_start = utc_now()
-        actual_authz_results = is_batch_authorized(requests, policies, entities, schema, verbose=True)
+        actual_authz_results = is_authorized_batch(requests, policies, entities, schema, verbose=True)
         self.assertIsNotNone(actual_authz_results)
         self.assertEqual(len(expect_authz_results), len(actual_authz_results))
 

--- a/tests/unit/test_authorize.py
+++ b/tests/unit/test_authorize.py
@@ -427,6 +427,24 @@ class AuthorizeTestCase(unittest.TestCase):
         self.assertEqual(Decision.NoDecision, authz_result.decision)
         self.assertEqual(["failed to parse schema from request"],
                          authz_result.diagnostics.errors)
+    def test_is_authorized_with_policies_that_errors(self):
+        policies = "this is not a real policy"
+        entities = load_file_as_str("resources/sandbox_b/entities.json")
+        schema = load_file_as_str("resources/sandbox_b/schema.json")
+
+        request = {
+            "principal": 'User::"alice"',
+            "action": 'Action::"view"',
+            "resource": 'Photo::"alice_w2.jpg"',
+            "context": json.dumps({
+                "authenticated": False
+            })
+        }
+
+        authz_result: AuthzResult = is_authorized(request, policies, entities, schema=schema)
+        self.assertEqual(Decision.NoDecision, authz_result.decision)
+        self.assertEqual(1, len(authz_result.diagnostics.errors))
+        self.assertIn('policy parse errors:\nUnrecognized token', authz_result.diagnostics.errors[0])
 
     def test_authorized_batch_perf(self):
         policies = self.policies["alice"]

--- a/tests/unit/test_authorize.py
+++ b/tests/unit/test_authorize.py
@@ -215,10 +215,10 @@ class AuthorizeTestCase(unittest.TestCase):
 
             metrics = actual_authz_result['metrics']
             for metric_name in [
-                'total_duration_micros',
                 'parse_policies_duration_micros',
                 'parse_schema_duration_micros',
                 'load_entities_duration_micros',
+                'build_request_duration_micros',
                 'authz_duration_micros',
             ]:
                 self.assertIn(metric_name, metrics)


### PR DESCRIPTION
This change adds an `is_authorized_batch` function that authorizes a batch of authorization requests in one invocation.  The primary benefit of this function is that it amortizes the cost of:

* parsing policies
* parsing the schema
* building the EntitySet

In practice, those operations are much more expensive than actually authorizing access.

For details and discussion, see:

* #13 
* https://github.com/cedar-policy/rfcs/pull/14

`is_authorized_batch` is _much_ faster when you have multiple authorization requests that can use the same policies and entities.

**Performance**
In the `test_authorized_batch_perf` test, 7 requests for the 'sandbox_b' entities are evaluated.  Here are the total durations for those requests executed via `is_authorized` and `is_authorized_batch`:
```
num_requests: 7
t_single_elapsed:	0.06419
t_batch_elapsed:	0.004192
```

Even with a relatively simple set of policies and entities, the batch approach is an order of magnitude faster.

**Error Handling**
This change also improves error handling.  Now when policies can't be parsed, schema is not valid, or the request doesn't match the schema, then an AuthzResult will be returned with:

* a `decision` property equal to `Decision.NoDecision`
* the `diagnostics.errors` populated with error messages

**Misc**

The current batching impl is about as simple as it gets.  Intentionally so.

For example:
First, It does not (yet) integrate correlation mechanisms that are visible to the developer such as a correlationId or a tuple of (Request, AuthzResult) as discussed in https://github.com/cedar-policy/rfcs/pull/14.  Instead, the lib currently verifies results are returned in the same order as the requests with tests.

Second, it may be possible to process the authorizations in parallel with e.g. `rayon`.  But I wanted to verify there was a need for that first and get an understanding if that's safe from the Cedar team.