### PR TITLE
Support providing an optional correlation_id on request

### DIFF
--- a/cedarpy/__init__.py
+++ b/cedarpy/__init__.py
@@ -47,6 +47,10 @@ class AuthzResult:
         return Decision.Allow == self.decision
 
     @property
+    def correlation_id(self) -> Decision:
+        return self._authz_resp.get('correlation_id', None)
+
+    @property
     def diagnostics(self) -> Diagnostics:
         return self._diagnostics
 

--- a/tests/unit/test_authorize.py
+++ b/tests/unit/test_authorize.py
@@ -123,9 +123,9 @@ class AuthorizeTestCase(unittest.TestCase):
                                  {'authenticated': True},
                                  ])
         request = {
-            "principal": f"User::\"{username}\"",
-            "action": f"Action::\"{action}\"",
-            "resource": f"Photo::\"{photo_resource}\"",
+            "principal": f'User::"{username}"',
+            "action": f'Action::"{action}"',
+            "resource": f'Photo::"{photo_resource}"',
             "context": context
         }
         return request


### PR DESCRIPTION
Support providing an optional correlation_id on an authorization request so that it can be correlated with the AuthzResult.

cedar-py returns the list of `AuthzResult` objects in the same order as the list of requests provided in the batch.

The optional correlation_id helps you verify that.

Say you build a batch of requests with code like:

```python3
batch_id:str = randomstr()
requests: List[dict] = []
for action_name in action_names:
    requests.append({
        "principal": f'User::"{user_id}"',
        "action": f'Action::"{action_name}"',
        "resource": f'Resource::"{resource_id}"',
        "context": context_keys,
        "correlation_id": f"authz_req::{batch_id}-{action_name}"
    })

# ... resolve get policies, entities, schema ...

# process authorizations in batch
authz_results: List[AuthzResult] = is_authorized_batch(requests=requests, policies=policies, entities=entities, schema=schema)

# ... verify results came back in correct order via correlation_id ...
for request, result, in zip(requests, authz_results):
    assert request.get('correlation_id') == result.correlation_id

```