### PR TITLE
Update cedar dependency to 4.1.0 and add new utility methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "aho-corasick"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,7 +77,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -72,7 +87,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -80,15 +95,6 @@ name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
-
-[[package]]
-name = "arbitrary"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
-dependencies = [
- "derive_arbitrary",
-]
 
 [[package]]
 name = "arrayvec"
@@ -112,6 +118,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backtrace"
+version = "0.3.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "backtrace-ext"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+dependencies = [
+ "backtrace",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,24 +155,48 @@ checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+checksum = "f0481a0e032742109b1133a095184ee93d88f3dc9e0d28a5d033dc77a073f44f"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.6.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+checksum = "d2c54ff287cfc0a34f38a6b832ea1bd8e448a330b3e40a50859e6488bee07f22"
 
 [[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "borsh"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2506947f73ad44e344215ccd6403ac2ae18cd8e046e581a441bf8d199f257f03"
+dependencies = [
+ "cfg_aliases",
+]
 
 [[package]]
 name = "bumpalo"
@@ -158,48 +212,57 @@ checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 
 [[package]]
 name = "cedar-policy"
-version = "2.2.2"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fff6e68bbf53f124fa17e774be74bd0ebf5acd0c19135849a1e112e9a6f6e47"
+checksum = "32f68814a8eba45546354eca82f3b737dd458bdf8832c7e7b59c539e65dc5376"
 dependencies = [
  "cedar-policy-core",
+ "cedar-policy-formatter",
  "cedar-policy-validator",
  "itertools",
  "lalrpop-util",
+ "lazy_static",
+ "miette",
+ "nonempty",
  "ref-cast",
+ "semver",
  "serde",
  "serde_json",
+ "serde_with",
  "smol_str",
  "thiserror",
 ]
 
 [[package]]
 name = "cedar-policy-cli"
-version = "2.2.1"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b19665744e4c5ac03370d5739a9e0e0e81d3bc3a549193dab5a8b046304e2ed"
+checksum = "5f2ddcb1806a5bdf78009a60f40a71536265193ffd6fafb96a788cb16f32cfbf"
 dependencies = [
- "anyhow",
  "cedar-policy",
  "cedar-policy-formatter",
  "clap",
+ "miette",
+ "semver",
  "serde",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]
 name = "cedar-policy-core"
-version = "2.2.2"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b26bed332eff6af4aff69df795cb91970faa6baeae6303e6bcb326d4403035ab"
+checksum = "b579d88f6f6890ef907aac7ee1e7c17b34f08fcd95bc2e1de4540c3d171a7428"
 dependencies = [
- "arbitrary",
  "either",
- "ipnet",
  "itertools",
  "lalrpop",
  "lalrpop-util",
  "lazy_static",
+ "miette",
+ "nonempty",
+ "ref-cast",
  "regex",
  "rustc_lexer",
  "serde",
@@ -212,14 +275,15 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy-formatter"
-version = "2.2.2"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d763591db4cf6e4ee144131824f31b8fb1d0582bdda8aac1439cca9191c71d"
+checksum = "c945f73152b71f4c309ed39e771b66f44284ad0706e7777c04cba31482132f0d"
 dependencies = [
- "anyhow",
  "cedar-policy-core",
  "itertools",
+ "lazy_static",
  "logos",
+ "miette",
  "pretty",
  "regex",
  "smol_str",
@@ -227,13 +291,18 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy-validator"
-version = "2.2.2"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee8e8bbf7b8da78ba8726aebfb9724c3fd692268234add9d1e931b44348121c"
+checksum = "a1a694f40a7bb5ac8e1c5bdfc41002e53f0bcf65bba1ca992b284d261ef29781"
 dependencies = [
- "arbitrary",
  "cedar-policy-core",
  "itertools",
+ "lalrpop",
+ "lalrpop-util",
+ "lazy_static",
+ "miette",
+ "nonempty",
+ "ref-cast",
  "serde",
  "serde_json",
  "serde_with",
@@ -245,14 +314,14 @@ dependencies = [
 
 [[package]]
 name = "cedarpy"
-version = "0.4.1"
+version = "1.4.2"
 dependencies = [
  "anyhow",
  "cedar-policy",
  "cedar-policy-cli",
  "cedar-policy-formatter",
  "pyo3",
- "rustix",
+ "rustix 0.37.27",
  "serde",
  "serde_json",
 ]
@@ -262,6 +331,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -295,7 +370,7 @@ checksum = "2e53afce1efce6ed1f633cf0e57612fe51db54a1ee4fd8f8503d078fe02d69ae"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex",
  "strsim",
 ]
@@ -309,7 +384,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -331,10 +406,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
-name = "crunchy"
-version = "0.2.2"
+name = "cpufeatures"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "darling"
@@ -357,7 +445,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.43",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -368,25 +456,18 @@ checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.89",
 ]
 
 [[package]]
-name = "derive_arbitrary"
-version = "1.3.2"
+name = "digest"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.43",
+ "block-buffer",
+ "crypto-common",
 ]
-
-[[package]]
-name = "diff"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "dirs-next"
@@ -438,7 +519,7 @@ checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -464,6 +545,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,6 +564,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "hashbrown"
@@ -569,14 +666,8 @@ checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "ipnet"
-version = "2.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
 
 [[package]]
 name = "is-terminal"
@@ -586,15 +677,21 @@ checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi",
  "io-lifetimes",
- "rustix",
- "windows-sys",
+ "rustix 0.37.27",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
-name = "itertools"
-version = "0.10.5"
+name = "is_ci"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -615,53 +712,68 @@ dependencies = [
 ]
 
 [[package]]
-name = "lalrpop"
-version = "0.19.12"
+name = "keccak"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a1cbf952127589f2851ab2046af368fd20645491bb4b376f04b7f94d7a9837b"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e56f323e2d610628d1f5bdd39168a774674ac7989ed67011963bb3f71edd797"
 dependencies = [
  "ascii-canvas",
  "bit-set",
- "diff",
  "ena",
- "is-terminal",
  "itertools",
  "lalrpop-util",
  "petgraph",
+ "pico-args",
  "regex",
- "regex-syntax 0.6.29",
+ "regex-syntax",
+ "sha3",
  "string_cache",
  "term",
- "tiny-keccak",
  "unicode-xid",
+ "walkdir",
 ]
 
 [[package]]
 name = "lalrpop-util"
-version = "0.19.12"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3c48237b9604c5a4702de6b824e02006c3214327564636aef27c1028a8fa0ed"
+checksum = "108dc8f5dabad92c65a03523055577d847f5dcc00f3e7d3a68bc4d48e01d8fe1"
 dependencies = [
- "regex",
+ "regex-automata",
 ]
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.146"
+version = "0.2.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
 
 [[package]]
 name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
@@ -681,25 +793,35 @@ checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "logos"
-version = "0.12.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf8b031682c67a8e3d5446840f9573eb7fe26efe7ec8d195c9ac4c0647c502f1"
+checksum = "1c6b6e02facda28ca5fb8dbe4b152496ba3b1bd5a4b40bb2b1b2d8ad74e0f39b"
 dependencies = [
  "logos-derive",
 ]
 
 [[package]]
-name = "logos-derive"
-version = "0.12.1"
+name = "logos-codegen"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d849148dbaf9661a6151d1ca82b13bb4c4c128146a88d05253b38d4e2f496c"
+checksum = "b32eb6b5f26efacd015b000bfc562186472cd9b34bdba3f6b264e2a052676d10"
 dependencies = [
  "beef",
  "fnv",
+ "lazy_static",
  "proc-macro2",
  "quote",
- "regex-syntax 0.6.29",
- "syn 1.0.109",
+ "regex-syntax",
+ "syn 2.0.89",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e5d0c5463c911ef55624739fc353238b4e310f0144be1f875dc42fec6bfd5ec"
+dependencies = [
+ "logos-codegen",
 ]
 
 [[package]]
@@ -718,10 +840,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "miette"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4edc8853320c2a0dab800fbda86253c8938f6ea88510dc92c5f1ed20e794afc1"
+dependencies = [
+ "backtrace",
+ "backtrace-ext",
+ "cfg-if",
+ "miette-derive",
+ "owo-colors",
+ "serde",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf09caffaac8068c346b6df2a7fc27a177fd20b39421a39ce0a211bde679a6c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
+name = "nonempty"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "303e8749c804ccd6ca3b428de7fe0d86cb86bc7606bc15291f100fd487960bb8"
 
 [[package]]
 name = "num-traits"
@@ -733,10 +902,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.36.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "owo-colors"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
 
 [[package]]
 name = "parking_lot"
@@ -758,7 +942,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.3.5",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -781,6 +965,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,21 +978,20 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "pretty"
-version = "0.11.3"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f3aa1e3ca87d3b124db7461265ac176b40c277f37e503eaa29c9c75c037846"
+checksum = "b55c4d17d994b637e2f4daf6e5dc5d660d209d5642377d675d7a1c3ab69fa579"
 dependencies = [
  "arrayvec",
- "log",
  "typed-arena",
- "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -878,9 +1067,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -891,7 +1080,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -900,7 +1089,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -931,7 +1120,7 @@ checksum = "8d2275aab483050ab2a7364c1a46604865ee7d6906684e08db0f090acf74f9e7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -943,7 +1132,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.3",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -954,20 +1143,20 @@ checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.3",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc_lexer"
@@ -984,12 +1173,25 @@ version = "0.37.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
- "windows-sys",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc99bc2d4f1fed22595588a013687477aedf3cdcfb26558c559edb67b4d9b22e"
+dependencies = [
+ "bitflags 2.6.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.14",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1005,29 +1207,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "serde"
-version = "1.0.193"
+name = "semver"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+
+[[package]]
+name = "serde"
+version = "1.0.215"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1068,7 +1285,17 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.89",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest",
+ "keccak",
 ]
 
 [[package]]
@@ -1084,11 +1311,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
-name = "smol_str"
-version = "0.2.0"
+name = "smawk"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74212e6bbe9a4352329b2f68ba3130c15a3f26fe88ff22dbdc6cdd58fa85e99c"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
+name = "smol_str"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9676b89cd56310a87b93dec47b11af744f34d5fc9f367b829474eec0a891350d"
 dependencies = [
+ "borsh",
  "serde",
 ]
 
@@ -1125,6 +1359,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "supports-color"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8775305acf21c96926c900ad056abeef436701108518cf890020387236ac5a77"
+dependencies = [
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0a1e5168041f5f3ff68ff7d95dcb9c8749df29f6e7e89ada40dd4c9de404ee"
+
+[[package]]
+name = "supports-unicode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1137,9 +1392,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.43"
+version = "2.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee659fb5f3d355364e1f3e5bc10fb82068efbf824a1e9d1c9504244a6469ad53"
+checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1164,23 +1419,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.40"
+name = "terminal_size"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+dependencies = [
+ "rustix 0.38.25",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1211,15 +1487,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1241,10 +1508,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-normalization"
@@ -1272,10 +1551,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.11.0"
+name = "unicode-width"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"
@@ -1294,6 +1573,22 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -1322,7 +1617,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.89",
  "wasm-bindgen-shared",
 ]
 
@@ -1344,7 +1639,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.43",
+ "syn 2.0.89",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1372,6 +1667,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1383,7 +1687,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -1392,7 +1696,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1401,13 +1714,29 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -1417,10 +1746,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1429,10 +1770,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1441,13 +1800,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "cedarpy"
-version = "1.4.2"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "cedar-policy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cedarpy"
-version = "0.4.1"
-edition = "2021"
+version = "1.0.0"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
@@ -11,9 +11,9 @@ crate-type = ["cdylib"]
 [dependencies]
 pyo3 = "0.19.0"
 anyhow = "1.0"
-cedar-policy = "~2.2.0"
-cedar-policy-cli = "~2.2.0"
-cedar-policy-formatter = "~2.2.0"
+cedar-policy = "~4.1.0"
+cedar-policy-cli = "~4.1.0"
+cedar-policy-formatter = "~4.1.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cedarpy"
 version = "1.0.0"
-edition = "2024"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ from cedarpy import is_authorized, AuthzResult, Decision
 
 policies: str = "//a string containing cedar policies"
 entities: list = [  # a list of Cedar entities; can also be a json-formatted string of Cedar entities
-    {"uid": {"__expr": "User::\"alice\""}, "attrs": {}, "parents": []}
+    {"uid": {"__entity": { "type" : "User", "id" : "alice" }}, "attrs": {}, "parents": []}
     # ...
 ]
 request = {

--- a/cedarpy/__init__.py
+++ b/cedarpy/__init__.py
@@ -40,7 +40,7 @@ class AuthzResult:
 
     @property
     def decision(self) -> Decision:
-        return Decision[self._authz_resp['decision']]
+        return Decision(self._authz_resp['decision'])
 
     @property
     def allowed(self) -> bool:

--- a/cedarpy/__init__.py
+++ b/cedarpy/__init__.py
@@ -40,7 +40,7 @@ class AuthzResult:
 
     @property
     def decision(self) -> Decision:
-        return Decision(self._authz_resp['decision'])
+        return Decision[self._authz_resp['decision']]
 
     @property
     def allowed(self) -> bool:

--- a/cedarpy/__init__.py
+++ b/cedarpy/__init__.py
@@ -158,3 +158,24 @@ def format_policies(policies: str,
     :raises ValueError: if the input policies cannot be parsed
     """
     return _internal.format_policies(policies, line_width, indent_width)
+
+
+def policies_to_json_str(policies: str) -> str:
+    """Convert a cedar policy file to a json cedar policy file.
+
+    :param policies is a str containing the policies to be converted
+
+    :returns the json formatted policy
+    :raises ValueError: if the input policies cannot be parsed
+    """
+    return _internal.policies_to_json_str(policies)
+
+def policies_from_json_str(policies: str) -> str:
+    """Convert a json cedar policy file to a cedar policy file.
+
+    :param policies is a str containing the policies to be converted
+
+    :returns the cedar formatted policy
+    :raises ValueError: if the input policies cannot be parsed
+    """
+    return _internal.policies_from_json_str(policies)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -355,7 +355,7 @@ fn make_schema(schema_str: &Option<String>, verbose: bool) -> Option<Schema> {
             if verbose {
                 println!("schema: {}", schema_src.as_str());
             }
-            match Schema::from_str(&schema_src) {
+            match Schema::from_json_str(&schema_src) {
                 Ok(schema) => Some(schema),
                 Err(e) => {
                     // TODO: record this error

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,23 +329,13 @@ fn execute_authorization_request(
 }
 
 fn make_entities(entities_str: String, schema: &Option<Schema>, errs: &mut Vec<Error>) -> Entities {
-    let entities = match load_entities(entities_str, schema.as_ref()) {
+    match load_entities(entities_str, schema.as_ref()) {
         Ok(entities) => entities,
         Err(e) => {
             errs.push(e);
             Entities::empty()
         }
-    };
-    // // load actions from the schema and append into entities
-    // we could/may integrate this into the load_entities match
-    let entities = match load_actions_from_schema(entities, schema) {
-        Ok(entities) => entities,
-        Err(e) => {
-            errs.push(e);
-            Entities::empty()
-        }
-    };
-    entities
+    }
 }
 
 fn make_schema(schema_str: &Option<String>, verbose: bool) -> Option<Schema> {
@@ -374,25 +364,9 @@ fn make_schema(schema_str: &Option<String>, verbose: bool) -> Option<Schema> {
 /// Load an `Entities` object from the given JSON string and optional schema.
 fn load_entities(entities_str: String, schema: Option<&Schema>) -> Result<Entities> {
     return Entities::from_json_str(&entities_str, schema).context(format!(
-        "failed to parse entities from:\n{}\nwith schema\n{}", entities_str, schema.map(|_s|"schema").or(Some("none")).expect("wibble")
-    ));
+        "failed to parse entities from:\n{}", entities_str)
+    );
 }
-
-fn load_actions_from_schema(entities: Entities, schema: &Option<Schema>) -> Result<Entities> {
-    match schema {
-        Some(schema) => match schema.action_entities() {
-            Ok(action_entities) => Entities::from_entities(
-                entities
-                    .iter()
-                    .cloned()
-                    .chain(action_entities.iter().cloned()), Some(schema))
-            .context("failed to merge action entities into Entities"),
-            Err(e) => Err(e).context("failed to construct action entities"),
-        },
-        None => Ok(entities),
-    }
-}
-
 
 /// A Python module implemented in Rust.
 #[pymodule]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,16 +219,16 @@ fn to_request_args(request: &HashMap<String, String>) -> RequestArgs {
     let correlation_id: Option<String> = request.get(String::from("correlation_id").as_str()).cloned();
 
     let context_option = request.get(String::from("context").as_str());
-    let context_json_option: Option<String> = match context_option {
+    let context_json: Option<String> = match context_option {
         None => None, // context member not present
         Some(context) => Some(context.to_string())
     };
 
     RequestArgs {
-        principal: principal,
-        action: action,
-        resource: resource,
-        context_json: context_json_option,
+        principal,
+        action,
+        resource,
+        context_json,
         correlation_id,
     }
 }

--- a/tests/unit/resources/json/bob_policy.json
+++ b/tests/unit/resources/json/bob_policy.json
@@ -1,0 +1,135 @@
+{
+    "templates": {},
+    "staticPolicies": {
+        "policy0": {
+            "effect": "permit",
+            "principal": {
+                "op": "==",
+                "entity": {
+                    "type": "User",
+                    "id": "bob"
+                }
+            },
+            "action": {
+                "op": "==",
+                "entity": {
+                    "type": "Action",
+                    "id": "view"
+                }
+            },
+            "resource": {
+                "op": "All"
+            },
+            "conditions": []
+        },
+        "policy1": {
+            "effect": "permit",
+            "principal": {
+                "op": "All"
+            },
+            "action": {
+                "op": "==",
+                "entity": {
+                    "type": "Action",
+                    "id": "edit"
+                }
+            },
+            "resource": {
+                "op": "All"
+            },
+            "conditions": [
+                {
+                    "kind": "when",
+                    "body": {
+                        "==": {
+                            "left": {
+                                ".": {
+                                    "left": {
+                                        "Var": "resource"
+                                    },
+                                    "attr": "account"
+                                }
+                            },
+                            "right": {
+                                "Var": "principal"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        "policy2": {
+            "effect": "permit",
+            "principal": {
+                "op": "All"
+            },
+            "action": {
+                "op": "==",
+                "entity": {
+                    "type": "Action",
+                    "id": "delete"
+                }
+            },
+            "resource": {
+                "op": "All"
+            },
+            "conditions": [
+                {
+                    "kind": "when",
+                    "body": {
+                        "&&": {
+                            "left": {
+                                "&&": {
+                                    "left": {
+                                        "==": {
+                                            "left": {
+                                                ".": {
+                                                    "left": {
+                                                        "Var": "context"
+                                                    },
+                                                    "attr": "authenticated"
+                                                }
+                                            },
+                                            "right": {
+                                                "Value": true
+                                            }
+                                        }
+                                    },
+                                    "right": {
+                                        "has": {
+                                            "left": {
+                                                "Var": "resource"
+                                            },
+                                            "attr": "account"
+                                        }
+                                    }
+                                }
+                            },
+                            "right": {
+                                "==": {
+                                    "left": {
+                                        "Var": "principal"
+                                    },
+                                    "right": {
+                                        ".": {
+                                            "left": {
+                                                ".": {
+                                                    "left": {
+                                                        "Var": "resource"
+                                                    },
+                                                    "attr": "account"
+                                                }
+                                            },
+                                            "attr": "owner"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    },
+    "templateLinks": []
+}

--- a/tests/unit/resources/json/bob_policy1.cedar
+++ b/tests/unit/resources/json/bob_policy1.cedar
@@ -1,0 +1,23 @@
+permit (
+  principal == User::"bob",
+  action == Action::"view",
+  resource
+);
+
+permit (
+  principal,
+  action == Action::"edit",
+  resource
+)
+when { (resource["account"]) == principal };
+
+permit (
+  principal,
+  action == Action::"delete",
+  resource
+)
+when
+{
+  (((context["authenticated"]) == true) && (resource has "account")) &&
+  (principal == ((resource["account"])["owner"]))
+};

--- a/tests/unit/resources/json/bob_policy2.cedar
+++ b/tests/unit/resources/json/bob_policy2.cedar
@@ -1,0 +1,23 @@
+permit (
+  principal == User::"bob",
+  action == Action::"view",
+  resource
+);
+
+permit (
+  principal,
+  action == Action::"delete",
+  resource
+)
+when
+{
+  (((context["authenticated"]) == true) && (resource has "account")) &&
+  (principal == ((resource["account"])["owner"]))
+};
+
+permit (
+  principal,
+  action == Action::"edit",
+  resource
+)
+when { (resource["account"]) == principal };

--- a/tests/unit/resources/json/bob_policy3.cedar
+++ b/tests/unit/resources/json/bob_policy3.cedar
@@ -1,0 +1,23 @@
+permit (
+  principal,
+  action == Action::"edit",
+  resource
+)
+when { (resource["account"]) == principal };
+
+permit (
+  principal == User::"bob",
+  action == Action::"view",
+  resource
+);
+
+permit (
+  principal,
+  action == Action::"delete",
+  resource
+)
+when
+{
+  (((context["authenticated"]) == true) && (resource has "account")) &&
+  (principal == ((resource["account"])["owner"]))
+};

--- a/tests/unit/resources/json/bob_policy4.cedar
+++ b/tests/unit/resources/json/bob_policy4.cedar
@@ -1,0 +1,23 @@
+permit (
+  principal,
+  action == Action::"edit",
+  resource
+)
+when { (resource["account"]) == principal };
+
+permit (
+  principal,
+  action == Action::"delete",
+  resource
+)
+when
+{
+  (((context["authenticated"]) == true) && (resource has "account")) &&
+  (principal == ((resource["account"])["owner"]))
+};
+
+permit (
+  principal == User::"bob",
+  action == Action::"view",
+  resource
+);

--- a/tests/unit/resources/json/bob_policy5.cedar
+++ b/tests/unit/resources/json/bob_policy5.cedar
@@ -1,0 +1,23 @@
+permit (
+  principal,
+  action == Action::"delete",
+  resource
+)
+when
+{
+  (((context["authenticated"]) == true) && (resource has "account")) &&
+  (principal == ((resource["account"])["owner"]))
+};
+
+permit (
+  principal == User::"bob",
+  action == Action::"view",
+  resource
+);
+
+permit (
+  principal,
+  action == Action::"edit",
+  resource
+)
+when { (resource["account"]) == principal };

--- a/tests/unit/resources/json/bob_policy6.cedar
+++ b/tests/unit/resources/json/bob_policy6.cedar
@@ -1,0 +1,23 @@
+permit (
+  principal,
+  action == Action::"delete",
+  resource
+)
+when
+{
+  (((context["authenticated"]) == true) && (resource has "account")) &&
+  (principal == ((resource["account"])["owner"]))
+};
+
+permit (
+  principal,
+  action == Action::"edit",
+  resource
+)
+when { (resource["account"]) == principal };
+
+permit (
+  principal == User::"bob",
+  action == Action::"view",
+  resource
+);

--- a/tests/unit/resources/sandbox_b/entities.json
+++ b/tests/unit/resources/sandbox_b/entities.json
@@ -60,7 +60,8 @@
   },
   {
     "uid": {
-      "__entity": { "type" : "UserGroup", "id" : "alice_friends" }
+      "type" : "UserGroup",
+      "id" : "alice_friends"
     },
     "attrs": {},
     "parents": []

--- a/tests/unit/resources/sandbox_b/entities.json
+++ b/tests/unit/resources/sandbox_b/entities.json
@@ -1,7 +1,8 @@
 [
   {
-    "uid": {
-      "__expr": "User::\"alice\""
+    "uid" : {
+      "type" : "User",
+      "id" : "alice"
     },
     "attrs": {
       "department": "HardwareEngineering",
@@ -9,16 +10,17 @@
     },
     "parents": [
       {
-        "__expr": "UserGroup::\"alice_friends\""
+        "__entity": { "type" : "UserGroup", "id" : "alice_friends" }
       },
       {
-        "__expr": "UserGroup::\"AVTeam\""
+        "__entity": { "type" : "UserGroup", "id" : "AVTeam" }
       }
     ]
   },
   {
-    "uid": {
-      "__expr": "User::\"ahmad\""
+    "uid" : {
+      "type" : "User",
+      "id" : "ahmad"
     },
     "attrs": {
       "department": "HardwareEngineering",
@@ -27,8 +29,9 @@
     "parents": []
   },
   {
-    "uid": {
-      "__expr": "User::\"stacey\""
+    "uid" : {
+      "type" : "User",
+      "id" : "stacey"
     },
     "attrs": {
       "department": "Sales",
@@ -36,13 +39,14 @@
     },
     "parents": [
       {
-        "__expr": "UserGroup::\"alice_friends\""
+        "__entity": { "type" : "UserGroup", "id" : "alice_friends" }
       }
     ]
   },
   {
-    "uid": {
-      "__expr": "User::\"giuseppe\""
+    "uid" : {
+      "type" : "User",
+      "id" : "guiseppe"
     },
     "attrs": {
       "department": "CustomerSupport",
@@ -50,168 +54,175 @@
     },
     "parents": [
       {
-        "__expr": "UserGroup::\"AVTeam\""
+        "__entity": { "type" : "UserGroup", "id" : "AVTeam" }
       }
     ]
   },
   {
     "uid": {
-      "__expr": "UserGroup::\"alice_friends\""
+      "__entity": { "type" : "UserGroup", "id" : "alice_friends" }
     },
     "attrs": {},
     "parents": []
   },
   {
-    "uid": {
-      "__expr": "Photo::\"prototype_v0.jpg\""
+    "uid" : {
+      "type" : "Photo",
+      "id" : "prototype_v0.jpg"
     },
     "attrs": {
       "private": false,
-      "account": { "__expr" :  "Account::\"ahmad\"" },
+      "account": { "__entity": { "type" : "Account", "id" : "ahmad" } },
       "admins": []
     },
     "parents": [
       {
-        "__expr": "Album::\"device_prototypes\""
+        "__entity": { "type" : "Album", "id" : "device_prototypes" }
       }
     ]
   },
   {
-    "uid": {
-      "__expr": "Photo::\"vacation.jpg\""
+    "uid" : {
+      "type" : "Photo",
+      "id" : "vacation.jpg"
     },
     "attrs": {
       "private": false,
-      "account": { "__expr" :  "Account::\"alice\""},
+      "account": { "__entity": { "type" : "Account", "id" : "alice" } },
       "admins": []
     },
     "parents": [
       {
-        "__expr": "Album::\"alice_vacation\""
+        "__entity": { "type" : "Album", "id" : "alice_vacation" }
       }
     ]
   },
   {
-    "uid": {
-      "__expr": "Photo::\"alice_w2.jpg\""
+    "uid" : {
+      "type" : "Photo",
+      "id" : "alice_w2.jpg"
     },
     "attrs": {
       "private": true,
-      "account": { "__expr" :  "Account::\"alice\"" },
+      "account": { "__entity": { "type" : "Account", "id" : "alice" } },
       "admins": []
     },
     "parents": [
       {
-        "__expr": "Account::\"alice\""
+        "__entity": { "type" : "Account", "id" : "alice" }
       }
     ]
   },
   {
-    "uid": {
-      "__expr": "Photo::\"sales_projections.jpg\""
+    "uid" : {
+      "type" : "Photo",
+      "id" : "sales_projections.jpg"
     },
     "attrs": {
       "private": false,
-      "account": { "__expr" : "Account::\"stacey\""},
-      "admins": [ { "__expr" : "User::\"giuseppe\"" }]
+      "account": { "__entity": { "type" : "Account", "id" : "stacey" } },
+      "admins": [{ "__entity": { "type" : "User", "id" : "guiseppe" } }]
     },
     "parents": [
       {
-        "__expr": "Account::\"stacey\""
+        "__entity": { "type" : "Account", "id" : "stacey" }
       }
     ]
   },
   {
-    "uid": {
-      "__expr": "Album::\"device_prototypes\""
+    "uid" : {
+      "type" : "Album",
+      "id" : "device_prototypes"
     },
     "attrs": {
       "private": false,
-      "account": {
-        "__expr": "Account::\"alice\""
+      "account": { "__entity": { "type" : "Account", "id" : "alice" } },
+      "admins": []
+    },
+    "parents": []
+  },
+  {
+    "uid" : {
+      "type" : "Album",
+      "id" : "alice_vacation"
+    },
+    "attrs": {
+      "private": false,
+      "account": { "__entity": { "type" : "Account", "id" : "alice" } },
+      "admins": []
+    },
+    "parents": [
+      {
+        "__entity": { "type" : "Account", "id" : "alice" }
+      }
+    ]
+  },
+  {
+    "uid" : {
+      "type" : "Account",
+      "id" : "alice"
+    },
+    "attrs": {
+      "private": false,
+      "owner": {
+        "__entity": { "type" : "User", "id" : "alice" }
+      },
+      "admins": []
+    },
+    "parents": [
+      {
+        "__entity": { "type" : "AccountGroup", "id" : "GeronimoTeam" }
+      }
+    ]
+  },
+  {
+    "uid" : {
+      "type" : "Account",
+      "id" : "ahmad"
+    },
+    "attrs": {
+      "private": false,
+      "owner": {
+        "__entity": { "type" : "User", "id" : "ahmad" }
+      },
+      "admins": []
+    },
+    "parents": [
+      {
+        "__entity": { "type" : "AccountGroup", "id" : "GeronimoTeam" }
+      }
+    ]
+  },
+  {
+    "uid" : {
+      "type" : "Account",
+      "id" : "stacey"
+    },
+    "attrs": {
+      "private": false,
+      "owner": {
+        "__entity": { "type" : "User", "id" : "stacey" }
       },
       "admins": []
     },
     "parents": []
   },
   {
-    "uid": {
-      "__expr": "Album::\"alice_vacation\""
-    },
-    "attrs": {
-      "private": false,
-      "account": {
-        "__expr": "Account::\"alice\""
-      },
-      "admins": []
-    },
-    "parents": [
-      {
-        "__expr": "Account::\"alice\""
-      }
-    ]
-  },
-  {
-    "uid": {
-      "__expr": "Account::\"alice\""
-    },
-    "attrs": {
-      "private": false,
-      "owner": {
-        "__expr": "User::\"alice\""
-      },
-      "admins": []
-    },
-    "parents": [
-      {
-        "__expr": "AccountGroup::\"GeronimoTeam\""
-      }
-    ]
-  },
-  {
-    "uid": {
-      "__expr": "Account::\"ahmad\""
-    },
-    "attrs": {
-      "private": false,
-      "owner": {
-        "__expr": "User::\"ahmad\""
-      },
-      "admins": []
-    },
-    "parents": [
-      {
-        "__expr": "AccountGroup::\"GeronimoTeam\""
-      }
-    ]
-  },
-  {
-    "uid": {
-      "__expr": "Account::\"stacey\""
-    },
-    "attrs": {
-      "private": false,
-      "owner": {
-        "__expr": "User::\"stacey\""
-      },
-      "admins": []
-    },
-    "parents": []
-  },
-  {
-    "uid": {
-      "__expr": "UserGroup::\"AVTeam\""
+    "uid" : {
+      "type" : "UserGroup",
+      "id" : "AVTeam"
     },
     "attrs": {},
     "parents": []
   },
   {
-    "uid": {
-      "__expr": "AccountGroup::\"GeronimoTeam\""
+    "uid" : {
+      "type" : "UserGroup",
+      "id" : "GeronimoTeam"
     },
     "attrs": {
       "owner": {
-        "__expr": "User::\"alice\""
+        "__entity": { "type" : "User", "id" : "alice" }
       }
     },
     "parents": []

--- a/tests/unit/resources/sandbox_b/schema.json
+++ b/tests/unit/resources/sandbox_b/schema.json
@@ -24,7 +24,13 @@
         "shape": {
           "type": "Record",
           "additionalAttributes": false,
-          "attributes": {}
+          "attributes": {
+            "owner": {
+              "type": "Entity",
+              "name": "User",
+              "required": false
+            }
+          }
         },
         "memberOfTypes": []
       },

--- a/tests/unit/test_authorize.py
+++ b/tests/unit/test_authorize.py
@@ -468,7 +468,7 @@ class AuthorizeTestCase(unittest.TestCase):
         authz_result: AuthzResult = is_authorized(request, policies, entities, schema=schema)
         self.assertEqual(Decision.NoDecision, authz_result.decision)
         self.assertEqual(1, len(authz_result.diagnostics.errors))
-        self.assertIn('policy parse errors:\nUnrecognized token', authz_result.diagnostics.errors[0])
+        self.assertIn('policy parse errors:\nunexpected token `is`', authz_result.diagnostics.errors[0])
 
     def test_authorized_batch_perf(self):
         policies = self.policies["alice"]
@@ -545,4 +545,4 @@ class AuthorizeTestCase(unittest.TestCase):
             load_file_as_str("resources/json/bob_policy6.cedar"),
         ]
         result = format_policies(policies_from_json_str(json_str))
-        self.assertTrue(result in expected, msg='expected json to be parsed to cedar correctly')
+        self.assertIn(result, expected, msg='expected json to be parsed to cedar correctly')

--- a/tests/unit/test_authorize.py
+++ b/tests/unit/test_authorize.py
@@ -5,7 +5,7 @@ import unittest
 from datetime import timedelta
 from typing import List, Union
 
-from cedarpy import is_authorized, AuthzResult, Decision, is_authorized_batch, policies_from_json_str, policies_to_json_str, format_policies
+from cedarpy import is_authorized, AuthzResult, Decision, is_authorized_batch
 
 from unit import load_file_as_str, utc_now
 
@@ -451,6 +451,8 @@ class AuthorizeTestCase(unittest.TestCase):
         self.assertEqual(Decision.NoDecision, authz_result.decision)
         self.assertEqual(["failed to parse schema from request"],
                          authz_result.diagnostics.errors)
+
+
     def test_is_authorized_with_policies_that_errors(self):
         policies = "this is not a real policy"
         entities = load_file_as_str("resources/sandbox_b/entities.json")
@@ -526,23 +528,3 @@ class AuthorizeTestCase(unittest.TestCase):
             print(f'actual_authz_result.metrics: {actual_authz_result. metrics}')
             self.assert_authz_responses_equal(expect_authz_result, actual_authz_result,
                                               ignore_metric_values=True)
-
-    def test_policy_to_json(self):
-        result: dict = json.loads(policies_to_json_str(self.policies["bob"]))
-        expected: dict = json.loads(load_file_as_str("resources/json/bob_policy.json"))
-        self.assertEqual(expected, result, msg='expected cedar to be parsed to json correctly')
-
-    def test_policy_from_json(self):
-        json_str = load_file_as_str("resources/json/bob_policy.json")
-        # this is required as conversion order in rust cedar library is non deterministic so could be one of n! variants
-        # good thing bob only has three policies!!!
-        expected = [
-            load_file_as_str("resources/json/bob_policy1.cedar"),
-            load_file_as_str("resources/json/bob_policy2.cedar"),
-            load_file_as_str("resources/json/bob_policy3.cedar"),
-            load_file_as_str("resources/json/bob_policy4.cedar"),
-            load_file_as_str("resources/json/bob_policy5.cedar"),
-            load_file_as_str("resources/json/bob_policy6.cedar"),
-        ]
-        result = format_policies(policies_from_json_str(json_str))
-        self.assertIn(result, expected, msg='expected json to be parsed to cedar correctly')

--- a/tests/unit/test_authorize.py
+++ b/tests/unit/test_authorize.py
@@ -190,9 +190,6 @@ class AuthorizeTestCase(unittest.TestCase):
             # omit metrics
         })
         actual_authz_result: AuthzResult = is_authorized(request, self.policies["bob"], self.entities)
-        print(actual_authz_result)
-        for error in actual_authz_result.diagnostics.errors:
-            print(error)
         self.assert_authz_responses_equal(expect_authz_result, actual_authz_result)
 
     def test_authorize_basic_DENY(self):
@@ -212,9 +209,6 @@ class AuthorizeTestCase(unittest.TestCase):
             }
         })
         actual_authz_result: AuthzResult = is_authorized(request, self.policies["bob"], self.entities)
-        for error in actual_authz_result.diagnostics.errors:
-            print(error)
-
         self.assert_authz_responses_equal(expect_authz_result, actual_authz_result)
 
     def test_authorize_basic_shape_of_response(self):
@@ -386,9 +380,6 @@ class AuthorizeTestCase(unittest.TestCase):
         expect_authz_result = AuthzResult({"decision": "Allow", "diagnostics": {"reason": ["policy2"], "errors": []}})
         actual_authz_result = is_authorized(request, policies, entities,
                                             schema=schema)
-        for error in actual_authz_result.diagnostics.errors:
-            print(error)
-
         self.assert_authz_responses_equal(expect_authz_result, actual_authz_result)
 
     def test_authorized_batch_evaluates_authorization_and_returns_in_order(self):
@@ -528,3 +519,4 @@ class AuthorizeTestCase(unittest.TestCase):
             print(f'actual_authz_result.metrics: {actual_authz_result. metrics}')
             self.assert_authz_responses_equal(expect_authz_result, actual_authz_result,
                                               ignore_metric_values=True)
+

--- a/tests/unit/test_authorize.py
+++ b/tests/unit/test_authorize.py
@@ -5,7 +5,7 @@ import unittest
 from datetime import timedelta
 from typing import List, Union
 
-from cedarpy import is_authorized, AuthzResult, Decision, is_authorized_batch
+from cedarpy import is_authorized, AuthzResult, Decision, is_authorized_batch, policies_from_json_str, policies_to_json_str, format_policies
 
 from unit import load_file_as_str, utc_now
 
@@ -527,3 +527,22 @@ class AuthorizeTestCase(unittest.TestCase):
             self.assert_authz_responses_equal(expect_authz_result, actual_authz_result,
                                               ignore_metric_values=True)
 
+    def test_policy_to_json(self):
+        result: dict = json.loads(policies_to_json_str(self.policies["bob"]))
+        expected: dict = json.loads(load_file_as_str("resources/json/bob_policy.json"))
+        self.assertEqual(expected, result, msg='expected cedar to be parsed to json correctly')
+
+    def test_policy_from_json(self):
+        json_str = load_file_as_str("resources/json/bob_policy.json")
+        # this is required as conversion order in rust cedar library is non deterministic so could be one of n! variants
+        # good thing bob only has three policies!!!
+        expected = [
+            load_file_as_str("resources/json/bob_policy1.cedar"),
+            load_file_as_str("resources/json/bob_policy2.cedar"),
+            load_file_as_str("resources/json/bob_policy3.cedar"),
+            load_file_as_str("resources/json/bob_policy4.cedar"),
+            load_file_as_str("resources/json/bob_policy5.cedar"),
+            load_file_as_str("resources/json/bob_policy6.cedar"),
+        ]
+        result = format_policies(policies_from_json_str(json_str))
+        self.assertTrue(result in expected, msg='expected json to be parsed to cedar correctly')

--- a/tests/unit/test_authorize.py
+++ b/tests/unit/test_authorize.py
@@ -63,45 +63,51 @@ class AuthorizeTestCase(unittest.TestCase):
         }
         self.entities: List[dict] = [
             {
-                "uid": {
-                    "__expr": "User::\"alice\""
+                "uid" : {
+                    "type" : "User",
+                    "id" : "alice"
                 },
                 "attrs": {},
                 "parents": []
             },
             {
                 "uid": {
-                    "__expr": "User::\"bob\""
+                    "type" : "User",
+                    "id" : "bob"
                 },
                 "attrs": {},
                 "parents": []
             },
             {
                 "uid": {
-                    "__expr": "Photo::\"bobs-photo-1\""
+                    "type" : "Photo",
+                    "id" : "bobs-photo-1"
                 },
                 "attrs": {
-                    "account": {"__expr": "User::\"bob\""}
+                    "account": {"__entity": { "type" : "User", "id" : "bob"} }
                 },
                 "parents": []
             },
             {
                 "uid": {
-                    "__expr": "Action::\"view\""
-                },
-                "attrs": {},
-                "parents": []
-            },
-            {
-                "uid": {
-                    "__expr": "Action::\"edit\""
+                    "type" : "Action",
+                    "id" : "view"
                 },
                 "attrs": {},
                 "parents": []
             },
             {
                 "uid": {
-                    "__expr": "Action::\"delete\""
+                    "type" : "Action",
+                    "id" : "edit"
+                },
+                "attrs": {},
+                "parents": []
+            },
+            {
+                "uid": {
+                    "type" : "Action",
+                    "id" : "delete"
                 },
                 "attrs": {},
                 "parents": []
@@ -184,6 +190,9 @@ class AuthorizeTestCase(unittest.TestCase):
             # omit metrics
         })
         actual_authz_result: AuthzResult = is_authorized(request, self.policies["bob"], self.entities)
+        print(actual_authz_result)
+        for error in actual_authz_result.diagnostics.errors:
+            print(error)
         self.assert_authz_responses_equal(expect_authz_result, actual_authz_result)
 
     def test_authorize_basic_DENY(self):
@@ -197,13 +206,15 @@ class AuthorizeTestCase(unittest.TestCase):
         expect_authz_result = AuthzResult({
             'decision': 'Deny',
             'diagnostics': {
-                'errors': ['while evaluating policy policy2, encountered the '
-                           'following error: record does not have the '
-                           'required attribute: authenticated'],
+                'errors': ['error while evaluating policy `policy2`: record does not have the '
+                           'attribute `authenticated`'],
                 'reason': []
             }
         })
         actual_authz_result: AuthzResult = is_authorized(request, self.policies["bob"], self.entities)
+        for error in actual_authz_result.diagnostics.errors:
+            print(error)
+
         self.assert_authz_responses_equal(expect_authz_result, actual_authz_result)
 
     def test_authorize_basic_shape_of_response(self):
@@ -375,6 +386,9 @@ class AuthorizeTestCase(unittest.TestCase):
         expect_authz_result = AuthzResult({"decision": "Allow", "diagnostics": {"reason": ["policy2"], "errors": []}})
         actual_authz_result = is_authorized(request, policies, entities,
                                             schema=schema)
+        for error in actual_authz_result.diagnostics.errors:
+            print(error)
+
         self.assert_authz_responses_equal(expect_authz_result, actual_authz_result)
 
     def test_authorized_batch_evaluates_authorization_and_returns_in_order(self):

--- a/tests/unit/test_format_policy.py
+++ b/tests/unit/test_format_policy.py
@@ -12,49 +12,6 @@ class FormatPolicyTestCase(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
 
-        common_policies = """
-                permit(
-                    principal,
-                    action == Action::"edit",
-                    resource
-                )
-                when {
-                   resource.account == principal
-                };
-                permit(
-                    principal,
-                    action == Action::"delete",
-                    resource
-                )
-                when {
-                    context.authenticated == true
-                    &&
-                    resource has account && principal == resource.account.owner
-                }
-                ;
-
-        """.strip()
-        self.policies: dict[str, str] = {
-            "common": common_policies,
-            "alice": f"""
-                permit(
-                    principal == User::"alice",
-                    action == Action::"view",
-                    resource
-                )
-                ;
-                {common_policies}""".strip(),
-            "bob": f"""
-                permit(
-                    principal == User::"bob",
-                    action == Action::"view",
-                    resource
-                )
-                ;
-                {common_policies}""".strip(),
-        }
-
-
     def test_policy_gets_formatted(self):
         input_policy = dedent("""
             permit(
@@ -99,7 +56,7 @@ class FormatPolicyTestCase(unittest.TestCase):
             pass
 
     def test_policy_to_json(self):
-        result: dict = json.loads(policies_to_json_str(self.policies["bob"]))
+        result: dict = json.loads(policies_to_json_str(load_file_as_str("resources/json/bob_policy1.cedar")))
         expected: dict = json.loads(load_file_as_str("resources/json/bob_policy.json"))
         self.assertEqual(expected, result, msg='expected cedar to be parsed to json correctly')
 

--- a/tests/unit/test_format_policy.py
+++ b/tests/unit/test_format_policy.py
@@ -2,11 +2,58 @@ import unittest
 
 from textwrap import dedent
 
-from cedarpy import format_policies
+from cedarpy import format_policies, policies_from_json_str, policies_to_json_str
+
+from unit import load_file_as_str
+
+import json
 
 class FormatPolicyTestCase(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
+
+        common_policies = """
+                permit(
+                    principal,
+                    action == Action::"edit",
+                    resource
+                )
+                when {
+                   resource.account == principal
+                };
+                permit(
+                    principal,
+                    action == Action::"delete",
+                    resource
+                )
+                when {
+                    context.authenticated == true
+                    &&
+                    resource has account && principal == resource.account.owner
+                }
+                ;
+
+        """.strip()
+        self.policies: dict[str, str] = {
+            "common": common_policies,
+            "alice": f"""
+                permit(
+                    principal == User::"alice",
+                    action == Action::"view",
+                    resource
+                )
+                ;
+                {common_policies}""".strip(),
+            "bob": f"""
+                permit(
+                    principal == User::"bob",
+                    action == Action::"view",
+                    resource
+                )
+                ;
+                {common_policies}""".strip(),
+        }
+
 
     def test_policy_gets_formatted(self):
         input_policy = dedent("""
@@ -50,3 +97,24 @@ class FormatPolicyTestCase(unittest.TestCase):
             self.fail("should have failed to parse")
         except ValueError as e:
             pass
+
+    def test_policy_to_json(self):
+        result: dict = json.loads(policies_to_json_str(self.policies["bob"]))
+        expected: dict = json.loads(load_file_as_str("resources/json/bob_policy.json"))
+        self.assertEqual(expected, result, msg='expected cedar to be parsed to json correctly')
+
+    def test_policy_from_json(self):
+        json_str = load_file_as_str("resources/json/bob_policy.json")
+        # this is required as conversion order in rust cedar library is non deterministic so could be one of n! variants
+        # good thing bob only has three policies!!!
+        expected = [
+            load_file_as_str("resources/json/bob_policy1.cedar"),
+            load_file_as_str("resources/json/bob_policy2.cedar"),
+            load_file_as_str("resources/json/bob_policy3.cedar"),
+            load_file_as_str("resources/json/bob_policy4.cedar"),
+            load_file_as_str("resources/json/bob_policy5.cedar"),
+            load_file_as_str("resources/json/bob_policy6.cedar"),
+        ]
+        result = format_policies(policies_from_json_str(json_str))
+        self.assertIn(result, expected, msg='expected json to be parsed to cedar correctly')
+

--- a/tests/unit/test_format_policy.py
+++ b/tests/unit/test_format_policy.py
@@ -27,7 +27,7 @@ class FormatPolicyTestCase(unittest.TestCase):
               resource
             )
             when { resource.owner == principal };
-        """).strip()
+        """).lstrip()
 
         actual_result = format_policies(input_policy, indent_width=2)
 


### PR DESCRIPTION
- Update cedar dependency to 4.1.0 this causes breaking changes in input schema so also upgrading cedarpy version to 1.0.0 as per semantic versioning guidelines
- Add new methods to convert cedar policies to/from cedar natiive and json representation