### PR TITLE
Fix PyPI README display

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@
 name = "cedarpy"
 version = "4.7.0"
 edition = "2021"
+readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 
-dynamic = ["version"]
+dynamic = ["version", "readme"]
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
PyPi is not showing readme for latest release. 

<img width="828" height="162" alt="image" src="https://github.com/user-attachments/assets/2da1f01a-6342-451c-b6a9-0aa705618c4f" />

Suspect change to maturin 1.8+ requires readme in dynamic fields. 

Added readme to Cargo.toml and pyproject.toml dynamic array.