### PR TITLE
CLOUD-3665: bump pytest to 9.0.3 and refresh wheel/packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dev = [
     'maturin>=1.8,<2',
     'parameterized==0.9.0',
     'pip-tools>=7.4.1',
-    'pytest == 7.4.0',
+    'pytest >= 9.0.3',
     'pytest-benchmark >= 4.0.0',
 ]
 

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -12,29 +12,32 @@ iniconfig==2.0.0
     # via pytest
 maturin==1.10.2
     # via cedarpy (pyproject.toml)
-packaging==23.1
+packaging==26.1
     # via
     #   build
     #   pytest
+    #   wheel
 parameterized==0.9.0
     # via cedarpy (pyproject.toml)
 pip-tools==7.5.2
     # via cedarpy (pyproject.toml)
-pluggy==1.2.0
+pluggy==1.6.0
     # via pytest
 py-cpuinfo==9.0.0
     # via pytest-benchmark
+pygments==2.20.0
+    # via pytest
 pyproject-hooks==1.0.0
     # via
     #   build
     #   pip-tools
-pytest==7.4.0
+pytest==9.0.3
     # via
     #   cedarpy (pyproject.toml)
     #   pytest-benchmark
 pytest-benchmark==5.0.1
     # via cedarpy (pyproject.toml)
-wheel==0.40.0
+wheel==0.47.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
## Summary
- Bump `pytest` from 7.4.0 → 9.0.3 (CVE-2025-71176)
- Regenerate `requirements.dev.txt` with `--upgrade-package wheel --upgrade-package packaging`, pulling `wheel` 0.40.0 → 0.47.0 (CVE-2026-24049) and `packaging` 23.1 → 26.1
- Supersedes #40 (Dependabot's wheel-only bump), which failed Linux CI because the stale `packaging==23.1` lockfile pin conflicts with `wheel`'s new `packaging>=24.0` requirement

Tracks [CLOUD-3665](https://qualimente.atlassian.net/browse/CLOUD-3665).

Rust-side alerts (`time`, `keccak` in `Cargo.lock`) are addressed in a separate follow-up PR.

## Test plan
- [x] `pytest` — 51 passed locally against pytest 9.0.3
- [x] `make integration-tests` — 69 passed, 5 skipped
- [ ] CI green on all platforms (linux x86_64/aarch64, macos x86_64/aarch64, windows, sdist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
