### PR TITLE
chore: add Dependabot cooldown for pip, cargo, and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+# Dependabot configuration
+# Reference: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
+#
+# Cooldown delays version-update PRs until a release has been public for N days,
+# reducing exposure to newly-published compromised or unstable releases.
+# Cooldown does NOT apply to security-update PRs — those fire immediately.
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 7
+      include:
+        - "*"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 7
+      include:
+        - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 7
+      include:
+        - "*"


### PR DESCRIPTION
## Summary
Adds `.github/dependabot.yml` enabling a cooldown on version-update PRs for `pip`, `cargo`, and `github-actions` ecosystems.

## Why
Reduces exposure to newly-published compromised or unstable releases by delaying Dependabot version-update PRs for at least 7 days after a release is published (14 days for major version bumps).

**Important:** cooldown does **not** apply to security-update PRs. Those continue to fire immediately, since the vulnerability is already public and waiting only increases risk.

## Policy

| Release type | Cooldown |
|---|---|
| Major | 14 days |
| Minor | 7 days |
| Patch | 7 days |
| Default (fallback) | 7 days |

Applied identically to `pip`, `cargo`, and `github-actions`.

## Not addressed
Local developer `pip install` / `cargo update` is not throttled. Enforcing that would require switching Python to `uv` with `exclude-newer`, or a custom registry — significantly more infrastructure. Out of scope for this PR.

## Test plan
- [ ] GitHub accepts the config (no syntax errors in the Dependabot tab after merge)
- [ ] Next Dependabot cycle opens PRs only for releases ≥ 7 days old

🤖 Generated with [Claude Code](https://claude.com/claude-code)
