### PR TITLE
chore: fix Dependabot cooldown for github-actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,9 +35,8 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
+      # github-actions ecosystem only supports default-days; semver-* fields
+      # are rejected because action tags don't follow strict semver.
       default-days: 7
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 7
       include:
         - "*"


### PR DESCRIPTION
## Summary
Fixes Dependabot config validation error from #44: the `github-actions` ecosystem only supports `default-days` under `cooldown`. The `semver-major-days` / `semver-minor-days` / `semver-patch-days` fields are rejected for that ecosystem because action tags don't follow strict semver.

Removes those three fields from the `github-actions` block; `pip` and `cargo` keep the full semver-aware configuration.

Ref: validation error https://github.com/k9securityio/cedar-py/runs/72589483528

## Test plan
- [ ] Dependabot accepts the updated config (no validation errors after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
