### PR TITLE
chore: disable Dependabot version updates, keep security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,22 @@
 # Dependabot configuration
 # Reference: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
 #
-# Cooldown delays version-update PRs until a release has been public for N days,
-# reducing exposure to newly-published compromised or unstable releases.
-# Cooldown does NOT apply to security-update PRs — those fire immediately.
+# Policy: security updates only. Version-update PRs are disabled per
+# ecosystem via `open-pull-requests-limit: 0`. Security-update PRs are
+# managed separately in repo Settings -> Code security and continue to
+# fire when the GitHub Advisory Database reports a vulnerability
+# matching a pinned dep.
+#
+# The `cooldown` blocks are retained so the 7/14-day policy is already
+# in place if version updates are ever re-enabled. Cooldown does NOT
+# apply to security-update PRs.
 version: 2
 updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     cooldown:
       default-days: 7
       semver-major-days: 14
@@ -22,6 +29,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     cooldown:
       default-days: 7
       semver-major-days: 14
@@ -34,6 +42,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     cooldown:
       # github-actions ecosystem only supports default-days; semver-* fields
       # are rejected because action tags don't follow strict semver.


### PR DESCRIPTION
## Summary
Disable Dependabot version-update PRs on all three ecosystems by setting `open-pull-requests-limit: 0`. Security-update PRs (from the GitHub Advisory Database) are **not** affected by this config and continue to fire independently.

## Why
The first version-update cycle after enabling Dependabot opened 13 PRs, including bumps (e.g. `pyo3`) that require fresh benchmarking or other non-trivial validation we're not ready to absorb piecemeal. Preferring to pull version bumps on demand, while still being alerted to actual CVEs.

## What stays in place
- `cooldown` blocks are retained. If we re-enable version updates later (by removing `open-pull-requests-limit: 0`), the 7/14-day policy is already there.
- Security updates — managed via repo Settings → Code security → "Dependabot security updates". Unaffected by this config.

## Follow-up (out of scope)
Close the 13 open version-update PRs with `@dependabot close`. Scripted batch-close after this merges.

## Test plan
- [ ] No new version-update PRs appear after next weekly Dependabot cycle
- [ ] Next security advisory still opens a PR (validated naturally the next time one fires)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
