### PR TITLE
release: bump version to 4.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "cedarpy"
-version = "4.8.0"
+version = "4.8.1"
 dependencies = [
  "anyhow",
  "cedar-policy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 # Maturin merges package metadata from pyproject.toml (preferred) and Cargo.toml
 # c.f. https://github.com/PyO3/maturin?tab=readme-ov-file#python-metadata
 name = "cedarpy"
-version = "4.8.0"
+version = "4.8.1"
 edition = "2021"
 readme = "README.md"
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <table>
 <thead><tr><th>Cedar Policy (engine) release</th><th>cedarpy release</th><th>cedarpy branch</th></tr></thead>
 <tbody>
-    <tr><td>v4.8.2</td><td>v4.8.0</td><td>main</td></tr>
+    <tr><td>v4.8.2</td><td>v4.8.1</td><td>main</td></tr>
     <tr><td>v4.7.2</td><td>v4.7.1</td><td>release/4.7.x</td></tr>
     <tr><td>v4.1.0</td><td>v4.1.0</td><td>release/4.1.x</td></tr>
     <tr><td>v2.2.0</td><td>v0.4.1</td><td>release/2.2.x</td></tr>


### PR DESCRIPTION
## Summary
Release `cedarpy` v4.8.1. Dependency update release — no functional or API changes.

## Version bumps
- `Cargo.toml`: `4.8.0` → `4.8.1`
- `Cargo.lock`: cedarpy entry auto-regenerated
- `README.md`: cedarpy release column in the compatibility table

## Changes since v4.8.0 (release notes)

### Security
- **pytest** 7.4.0 → 9.0.3 — CVE-2025-71176
- **wheel** 0.40.0 → 0.47.0 — CVE-2026-24049
- **time** 0.3.37 → 0.3.47 — CVE-2026-25727
- **keccak** 0.1.5 → 0.1.6 — GHSA-3288-p39f-rqpv

### Build / supply chain
- Removed stale `rustix = "~0.37.25"` pin; `rustix` is now governed by the transitive dep graph (resolves to 0.38.x)
- Added Dependabot cooldown (7 days minor/patch, 14 days major) to mitigate fresh-release compromise risk
- Switched PyPI publish from long-lived API token to **Trusted Publishing** (OIDC) with a protected `pypi-release` environment

### No functional changes
Cedar Policy engine version is unchanged (still 4.8.2).

## Release procedure
1. Merge this PR to `main`
2. `git tag -a v4.8.1 -m "cedarpy v4.8.1"` on main
3. `git push origin v4.8.1`
4. Approve the `pypi-release` deployment in GitHub Actions when it pauses for review
5. Wheels publish to PyPI via OIDC
6. Draft GitHub Release notes from this PR body

## Test plan
- [x] `cargo build` — cedarpy 4.8.1 builds cleanly
- [x] `make benchmark-compare` passed (verified locally by maintainer)
- [ ] CI green on all platforms (linux x86_64/aarch64, macos x86_64/aarch64, windows, sdist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
