### PR TITLE
fix: surface invalid schema as NoDecision with diagnostic error (#27)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ fn is_authorized_batch(requests: Vec<HashMap<String, String>>,
 
     // parse schema
     let t_start_schema = Instant::now();
-    let schema = make_schema(&schema, verbose);
+    let schema = make_schema(&schema, verbose, &mut errs);
     let t_parse_schema_duration = t_start_schema.elapsed();
 
     // load entities
@@ -356,7 +356,7 @@ fn make_entities(entities_str: String, schema: &Option<Schema>, errs: &mut Vec<E
     }
 }
 
-fn make_schema(schema_str: &Option<String>, verbose: bool) -> Option<Schema> {
+fn make_schema(schema_str: &Option<String>, verbose: bool, errs: &mut Vec<Error>) -> Option<Schema> {
     let schema: Option<Schema> = match &schema_str {
         None => None,
         Some(schema_src) => {
@@ -377,6 +377,7 @@ fn make_schema(schema_str: &Option<String>, verbose: bool) -> Option<Schema> {
                         if verbose {
                             println!("!!! could not construct schema from JSON: {}", json_err);
                         }
+                        errs.push(Error::msg(format!("failed to parse schema as JSON: {}", json_err)));
                         None
                     }
                 }
@@ -387,12 +388,13 @@ fn make_schema(schema_str: &Option<String>, verbose: bool) -> Option<Schema> {
                         if verbose {
                             println!("!!! could not construct schema from str: {}", str_err);
                         }
+                        errs.push(Error::msg(format!("failed to parse schema: {}", str_err)));
                         None
                     }
                 }
             }
         }
-    };    
+    };
     schema
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,7 +377,7 @@ fn make_schema(schema_str: &Option<String>, verbose: bool, errs: &mut Vec<Error>
                         if verbose {
                             println!("!!! could not construct schema from JSON: {}", json_err);
                         }
-                        errs.push(Error::msg(format!("failed to parse schema as JSON: {}", json_err)));
+                        errs.push(Error::msg(format!("failed to parse schema from JSON: {}", json_err)));
                         None
                     }
                 }
@@ -388,7 +388,7 @@ fn make_schema(schema_str: &Option<String>, verbose: bool, errs: &mut Vec<Error>
                         if verbose {
                             println!("!!! could not construct schema from str: {}", str_err);
                         }
-                        errs.push(Error::msg(format!("failed to parse schema: {}", str_err)));
+                        errs.push(Error::msg(format!("failed to parse schema from Cedar: {}", str_err)));
                         None
                     }
                 }

--- a/tests/unit/test_authorize.py
+++ b/tests/unit/test_authorize.py
@@ -463,6 +463,45 @@ class AuthorizeTestCase(unittest.TestCase):
         self.assertEqual(1, len(authz_result.diagnostics.errors))
         self.assertIn('policy parse errors:\nunexpected token `is`', authz_result.diagnostics.errors[0])
 
+    def test_is_authorized_with_invalid_cedar_schema_returns_no_decision(self):
+        # Regression for https://github.com/k9securityio/cedar-py/issues/27
+        # Invalid (non-empty) schemas previously returned a real decision while
+        # silently dropping the schema. Now they must surface as NoDecision +
+        # a diagnostic error.
+        policies = self.policies["alice"]
+        entities = load_file_as_str("resources/sandbox_b/entities.json")
+        invalid_schema = "this is definitely not a cedar schema"
+
+        request = {
+            "principal": 'User::"alice"',
+            "action": 'Action::"view"',
+            "resource": 'Photo::"alice_w2.jpg"',
+            "context": json.dumps({"authenticated": False}),
+        }
+
+        authz_result: AuthzResult = is_authorized(request, policies, entities, schema=invalid_schema)
+        self.assertEqual(Decision.NoDecision, authz_result.decision)
+        self.assertEqual(1, len(authz_result.diagnostics.errors))
+        self.assertIn("schema", authz_result.diagnostics.errors[0].lower())
+
+    def test_is_authorized_with_invalid_json_schema_returns_no_decision(self):
+        # Regression for https://github.com/k9securityio/cedar-py/issues/27
+        policies = self.policies["alice"]
+        entities = load_file_as_str("resources/sandbox_b/entities.json")
+        invalid_json_schema = '{"not a valid": "cedar json schema"}'
+
+        request = {
+            "principal": 'User::"alice"',
+            "action": 'Action::"view"',
+            "resource": 'Photo::"alice_w2.jpg"',
+            "context": json.dumps({"authenticated": False}),
+        }
+
+        authz_result: AuthzResult = is_authorized(request, policies, entities, schema=invalid_json_schema)
+        self.assertEqual(Decision.NoDecision, authz_result.decision)
+        self.assertEqual(1, len(authz_result.diagnostics.errors))
+        self.assertIn("schema", authz_result.diagnostics.errors[0].lower())
+
     def test_authorized_batch_perf(self):
         import platform
 


### PR DESCRIPTION
## Summary
- Fixes #27: cedar-py used to silently swallow invalid schemas, returning a real Allow/Deny computed without the schema.
- `make_schema` now pushes parse errors into the same `errs` vec used by `make_entities` and policy parsing. The existing `errs.is_empty()` check then routes the response through `make_authz_result_for_errors`, producing `NoDecision` + a diagnostic error — matching the behavior already in place for invalid policies and entities.
- Covers both Cedar schema syntax and JSON schema parse failures.

## Behavior
Before:
```python
authz_result = is_authorized(request, policies, entities, schema="not a schema")
authz_result.decision         # Decision.Allow (or Deny) — schema silently ignored
authz_result.diagnostics.errors  # []
```

After:
```python
authz_result = is_authorized(request, policies, entities, schema="not a schema")
authz_result.decision         # Decision.NoDecision
authz_result.diagnostics.errors  # ["failed to parse schema: ..."]
```

This aligns with the direction @skuenzli suggested in [issue #27](https://github.com/k9securityio/cedar-py/issues/27#issuecomment-...): model the failure as `NoDecision` with diagnostics rather than silent fallback.

## Test plan
- [x] Added two regression tests in `tests/unit/test_authorize.py` (Cedar-syntax and JSON-syntax invalid schemas) — both fail before the fix and pass after.
- [x] `pytest tests/unit` — 53 passed.
- [x] `make integration-tests` — 69 passed, 5 skipped, 0 failed.
- [x] No change in behavior for valid schemas, `None` schemas, or empty/whitespace-only schemas (existing tests cover these).