### PR TITLE
feat: honor @id("...") annotation as the policy id

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,14 @@ fn is_authorized_batch(requests: Vec<HashMap<String, String>>,
     // parse policies
     let t_parse_policies = Instant::now();
     let policy_set = match PolicySet::from_str(&policies) {
-        Ok(pset) => pset,
+        Ok(pset) => match rename_from_id_annotation(pset) {
+            Ok(renamed) => renamed,
+            Err(e) => {
+                println!("{:#}", e);
+                errs.push(e);
+                PolicySet::new()
+            }
+        },
         Err(parse_errors) => {
             let err_message = format!("policy parse errors:\n{:#}",
                                       parse_errors.to_string());
@@ -403,13 +410,65 @@ fn load_entities(entities_str: String, schema: Option<&Schema>) -> Result<Entiti
     );
 }
 
+/// Apply `@id("...")` annotations to override the auto-generated PolicyId of
+/// each policy and template. Mirrors cedar-policy-cli behavior so cedarpy
+/// users see human-readable ids in `AuthzResult.diagnostics.reasons` and in
+/// validation errors.
+///
+/// PolicyId::from_str is currently infallible, but we still propagate it as
+/// an error to be defensive against future API changes. Adding renamed
+/// policies/templates can fail on duplicate id, in which case the caller
+/// receives the conflict error.
+fn rename_from_id_annotation(ps: PolicySet) -> Result<PolicySet> {
+    let mut new_ps = PolicySet::new();
+    for t in ps.templates() {
+        let renamed = match t.annotation("id") {
+            None => t.clone(),
+            Some(anno) => {
+                let new_id: PolicyId = anno.parse().context(format!(
+                    "invalid @id annotation on template '{}': '{}'", t.id(), anno
+                ))?;
+                t.new_id(new_id)
+            }
+        };
+        new_ps.add_template(renamed)
+            .context("duplicate template id after applying @id annotation")?;
+    }
+    for p in ps.policies() {
+        let renamed = match p.annotation("id") {
+            None => p.clone(),
+            Some(anno) => {
+                let new_id: PolicyId = anno.parse().context(format!(
+                    "invalid @id annotation on policy '{}': '{}'", p.id(), anno
+                ))?;
+                p.new_id(new_id)
+            }
+        };
+        new_ps.add(renamed)
+            .context("duplicate policy id after applying @id annotation")?;
+    }
+    Ok(new_ps)
+}
+
 /// Validate Cedar policies against a schema and return a JSON result.
 #[pyfunction]
 #[pyo3(signature = (policies, schema))]
 fn validate_policies(policies: String, schema: String) -> String {
     // Parse policies
     let policy_set = match PolicySet::from_str(&policies) {
-        Ok(pset) => pset,
+        Ok(pset) => match rename_from_id_annotation(pset) {
+            Ok(renamed) => renamed,
+            Err(e) => {
+                let result = ValidationResultSer {
+                    validation_passed: false,
+                    errors: vec![ValidationErrorSer {
+                        policy_id: String::new(),
+                        error: format!("Policy id annotation error: {}", e),
+                    }],
+                };
+                return serde_json::to_string(&result).unwrap();
+            }
+        },
         Err(parse_errors) => {
             let result = ValidationResultSer {
                 validation_passed: false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,7 @@ fn is_authorized_batch(requests: Vec<HashMap<String, String>>,
     let policy_set = match PolicySet::from_str(&policies) {
         Ok(pset) => match rename_from_id_annotation(pset) {
             Ok(renamed) => renamed,
-            Err(e) => {
+            Err((_policy_id, e)) => {
                 println!("{:#}", e);
                 errs.push(e);
                 PolicySet::new()
@@ -419,33 +419,53 @@ fn load_entities(entities_str: String, schema: Option<&Schema>) -> Result<Entiti
 /// an error to be defensive against future API changes. Adding renamed
 /// policies/templates can fail on duplicate id, in which case the caller
 /// receives the conflict error.
-fn rename_from_id_annotation(ps: PolicySet) -> Result<PolicySet> {
+///
+/// On error, returns `(original_policy_id, Error)` so callers can surface the
+/// pre-rename id of the offending policy/template (e.g. as
+/// `ValidationError.policy_id`).
+fn rename_from_id_annotation(ps: PolicySet) -> Result<PolicySet, (String, Error)> {
     let mut new_ps = PolicySet::new();
     for t in ps.templates() {
+        let original_id = t.id().to_string();
         let renamed = match t.annotation("id") {
             None => t.clone(),
-            Some(anno) => {
-                let new_id: PolicyId = anno.parse().context(format!(
-                    "invalid @id annotation on template '{}': '{}'", t.id(), anno
-                ))?;
-                t.new_id(new_id)
-            }
+            Some(anno) => match anno.parse::<PolicyId>() {
+                Ok(new_id) => t.new_id(new_id),
+                Err(e) => return Err((
+                    original_id.clone(),
+                    Error::new(e).context(format!(
+                        "invalid @id annotation on template '{}': '{}'", original_id, anno
+                    )),
+                )),
+            },
         };
-        new_ps.add_template(renamed)
-            .context("duplicate template id after applying @id annotation")?;
+        if let Err(e) = new_ps.add_template(renamed) {
+            return Err((
+                original_id,
+                Error::new(e).context("duplicate template id after applying @id annotation"),
+            ));
+        }
     }
     for p in ps.policies() {
+        let original_id = p.id().to_string();
         let renamed = match p.annotation("id") {
             None => p.clone(),
-            Some(anno) => {
-                let new_id: PolicyId = anno.parse().context(format!(
-                    "invalid @id annotation on policy '{}': '{}'", p.id(), anno
-                ))?;
-                p.new_id(new_id)
-            }
+            Some(anno) => match anno.parse::<PolicyId>() {
+                Ok(new_id) => p.new_id(new_id),
+                Err(e) => return Err((
+                    original_id.clone(),
+                    Error::new(e).context(format!(
+                        "invalid @id annotation on policy '{}': '{}'", original_id, anno
+                    )),
+                )),
+            },
         };
-        new_ps.add(renamed)
-            .context("duplicate policy id after applying @id annotation")?;
+        if let Err(e) = new_ps.add(renamed) {
+            return Err((
+                original_id,
+                Error::new(e).context("duplicate policy id after applying @id annotation"),
+            ));
+        }
     }
     Ok(new_ps)
 }
@@ -458,11 +478,11 @@ fn validate_policies(policies: String, schema: String) -> String {
     let policy_set = match PolicySet::from_str(&policies) {
         Ok(pset) => match rename_from_id_annotation(pset) {
             Ok(renamed) => renamed,
-            Err(e) => {
+            Err((policy_id, e)) => {
                 let result = ValidationResultSer {
                     validation_passed: false,
                     errors: vec![ValidationErrorSer {
-                        policy_id: String::new(),
+                        policy_id,
                         error: format!("Policy id annotation error: {}", e),
                     }],
                 };

--- a/tests/unit/test_authorize.py
+++ b/tests/unit/test_authorize.py
@@ -463,6 +463,100 @@ class AuthorizeTestCase(unittest.TestCase):
         self.assertEqual(1, len(authz_result.diagnostics.errors))
         self.assertIn('policy parse errors:\nunexpected token `is`', authz_result.diagnostics.errors[0])
 
+    def test_id_annotation_renames_policy_id_in_reasons(self):
+        # Feature from https://github.com/k9securityio/cedar-py/issues/29 (item 2)
+        # An @id("...") annotation should override the auto-generated policyN id,
+        # so AuthzResult.diagnostics.reasons surfaces the human-readable id.
+        policies = """
+            @id("alice_can_view")
+            permit(
+                principal == User::"alice",
+                action == Action::"view",
+                resource
+            );
+        """.strip()
+
+        request = {
+            "principal": 'User::"alice"',
+            "action": 'Action::"view"',
+            "resource": 'Photo::"alice_w2.jpg"',
+            "context": {},
+        }
+
+        authz_result: AuthzResult = is_authorized(request, policies, self.entities)
+        self.assertEqual(Decision.Allow, authz_result.decision)
+        self.assertEqual(["alice_can_view"], authz_result.diagnostics.reasons)
+
+    def test_id_annotation_mixed_with_unannotated_policies(self):
+        # Mix annotated + un-annotated policies. Annotated policy keeps its
+        # custom id; un-annotated policy retains the auto-generated id.
+        policies = """
+            @id("alice_view")
+            permit(
+                principal == User::"alice",
+                action == Action::"view",
+                resource
+            );
+            permit(
+                principal == User::"bob",
+                action == Action::"view",
+                resource
+            );
+        """.strip()
+
+        alice_request = {
+            "principal": 'User::"alice"',
+            "action": 'Action::"view"',
+            "resource": 'Photo::"alice_w2.jpg"',
+            "context": {},
+        }
+        bob_request = {
+            "principal": 'User::"bob"',
+            "action": 'Action::"view"',
+            "resource": 'Photo::"bobs-photo-1"',
+            "context": {},
+        }
+
+        alice_result: AuthzResult = is_authorized(alice_request, policies, self.entities)
+        self.assertEqual(Decision.Allow, alice_result.decision)
+        self.assertEqual(["alice_view"], alice_result.diagnostics.reasons)
+
+        bob_result: AuthzResult = is_authorized(bob_request, policies, self.entities)
+        self.assertEqual(Decision.Allow, bob_result.decision)
+        # un-annotated policy keeps cedar's default id (some "policyN")
+        self.assertEqual(1, len(bob_result.diagnostics.reasons))
+        self.assertNotEqual("alice_view", bob_result.diagnostics.reasons[0])
+
+    def test_id_annotation_duplicate_returns_no_decision(self):
+        # Two policies that resolve to the same @id are a configuration error;
+        # surface as NoDecision + diagnostic rather than silently dropping one.
+        policies = """
+            @id("dup")
+            permit(
+                principal == User::"alice",
+                action == Action::"view",
+                resource
+            );
+            @id("dup")
+            permit(
+                principal == User::"bob",
+                action == Action::"view",
+                resource
+            );
+        """.strip()
+
+        request = {
+            "principal": 'User::"alice"',
+            "action": 'Action::"view"',
+            "resource": 'Photo::"alice_w2.jpg"',
+            "context": {},
+        }
+
+        authz_result: AuthzResult = is_authorized(request, policies, self.entities)
+        self.assertEqual(Decision.NoDecision, authz_result.decision)
+        self.assertEqual(1, len(authz_result.diagnostics.errors))
+        self.assertIn("duplicate policy id", authz_result.diagnostics.errors[0].lower())
+
     def test_authorized_batch_perf(self):
         import platform
 

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -152,6 +152,22 @@ class ValidatePoliciesTestCase(unittest.TestCase):
         self.assertIn("ValidationResult", repr_str)
         self.assertIn("validation_passed=True", repr_str)
 
+    def test_id_annotation_renames_policy_id_in_validation_errors(self):
+        """Validation errors should report the @id-annotated policy id."""
+        policy_with_id = """
+            @id("alice_view_bad_entity")
+            permit(
+                principal == Usr::"alice",
+                action == Action::"view",
+                resource
+            );
+        """
+        result = validate_policies(policy_with_id, self.schema)
+
+        self.assertFalse(result.validation_passed)
+        self.assertGreater(len(result.errors), 0)
+        self.assertEqual("alice_view_bad_entity", result.errors[0].policy_id)
+
 
 class ValidatePoliciesWithCedarSchemaTestCase(unittest.TestCase):
     """Tests for validate_policies with Cedar schema syntax (not JSON)."""

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -180,8 +180,10 @@ class ValidatePoliciesTestCase(unittest.TestCase):
         The current diagnostic returned by validate_policies:
           - validation_passed:  False
           - errors:             single ValidationError
-          - errors[0].policy_id:  ''  (empty — the offending policy's
-                                       pre-rename id is not propagated yet)
+          - errors[0].policy_id:  the offending policy's pre-rename id
+                                  (e.g. 'policy1' for the second of two
+                                  duplicates), so callers can locate the
+                                  conflict in their input
           - errors[0].error:    starts with 'Policy id annotation error:'
                                 and contains 'duplicate policy id'
 
@@ -208,7 +210,7 @@ class ValidatePoliciesTestCase(unittest.TestCase):
         self.assertEqual(1, len(result.errors))
 
         err = result.errors[0]
-        self.assertEqual("", err.policy_id)
+        self.assertEqual("policy1", err.policy_id)
         self.assertTrue(
             err.error.startswith("Policy id annotation error:"),
             f"unexpected error prefix: {err.error!r}",

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -168,6 +168,53 @@ class ValidatePoliciesTestCase(unittest.TestCase):
         self.assertGreater(len(result.errors), 0)
         self.assertEqual("alice_view_bad_entity", result.errors[0].policy_id)
 
+    def test_validate_with_duplicate_policy_id_annotations(self):
+        """Document the library's behavior when a caller declares two
+        policies with the same @id annotation.
+
+        Pre-PR-66, cedarpy ignored @id entirely, so duplicate annotations
+        were inert — validation proceeded against whatever cedar's
+        auto-generated ids were. After PR-66, duplicates are surfaced as a
+        validation failure.
+
+        The current diagnostic returned by validate_policies:
+          - validation_passed:  False
+          - errors:             single ValidationError
+          - errors[0].policy_id:  ''  (empty — the offending policy's
+                                       pre-rename id is not propagated yet)
+          - errors[0].error:    starts with 'Policy id annotation error:'
+                                and contains 'duplicate policy id'
+
+        This test exists to make any future change to that behavior
+        deliberate and visible in diffs.
+        """
+        policies = """
+            @id("dup")
+            permit(
+                principal == User::"alice",
+                action == Action::"view",
+                resource
+            );
+            @id("dup")
+            permit(
+                principal == User::"bob",
+                action == Action::"view",
+                resource
+            );
+        """
+        result = validate_policies(policies, self.schema)
+
+        self.assertFalse(result.validation_passed)
+        self.assertEqual(1, len(result.errors))
+
+        err = result.errors[0]
+        self.assertEqual("", err.policy_id)
+        self.assertTrue(
+            err.error.startswith("Policy id annotation error:"),
+            f"unexpected error prefix: {err.error!r}",
+        )
+        self.assertIn("duplicate policy id", err.error.lower())
+
 
 class ValidatePoliciesWithCedarSchemaTestCase(unittest.TestCase):
     """Tests for validate_policies with Cedar schema syntax (not JSON)."""


### PR DESCRIPTION
## Summary
Addresses item 2 of the feature wish-list in #29: cedar parses `@id("...")` annotations on policies and templates, but cedarpy used the auto-generated `policy0`/`policy1`/... ids regardless. This made `AuthzResult.diagnostics.reasons` and validation errors reference opaque numeric ids instead of the names users wrote in their policies.

After this PR:

```cedar
@id("alice_can_view")
permit(principal == User::"alice", action == Action::"view", resource);
```

```python
authz_result = is_authorized(req, policies, entities)
authz_result.diagnostics.reasons   # ["alice_can_view"]   (was ["policy0"])
```

Same applies to `validate_policies`: `ValidationError.policy_id` now reports the `@id`-named id when validation fails.

## Implementation
- New helper `rename_from_id_annotation` in `src/lib.rs`, modeled on the same-named function in `cedar-policy-cli`.
- Applied right after `PolicySet::from_str` in both `is_authorized_batch` and `validate_policies`.
- Two failure modes are surfaced as diagnostics rather than panicking (the cedar-policy-cli reference uses `.expect(...)` which would panic in a library context):
  - **Duplicate id** — two policies (or templates) resolving to the same `@id` produce `Decision.NoDecision` with `"duplicate policy id after applying @id annotation"` in `diagnostics.errors`.
  - **Malformed PolicyId** — `PolicyId::from_str` is currently infallible upstream, but is defensively handled in case it grows fallibility.

Templates are also handled, even though cedarpy doesn't surface a templates API yet (#29 main item) — keeping the helper symmetric with cedar-policy-cli avoids re-touching this code when template support lands.

## Test plan
- [x] Added 4 unit tests:
  - `@id` rename surfaces in `diagnostics.reasons` for the matched policy
  - mixed annotated/un-annotated policies — annotated keeps custom id, un-annotated retains `policyN`
  - duplicate `@id` returns `NoDecision` + diagnostic
  - `validate_policies` reports the `@id`-named id in `ValidationError.policy_id`
- [x] `pytest tests/unit` — 55 passed, 0 failed.
- [x] `make integration-tests` — 69 passed, 5 skipped, 0 failed.
- [x] No change in behavior for policies without `@id` — existing tests asserting `policy0`/`policy1`/... continue to pass.

## Notes
- Independent of #65 (no shared lines).
- Worth flagging: this is a small **behavior change** — anyone authoring policies that happen to include an `@id("name")` annotation today (maybe as documentation) would suddenly see that name in their reasons/error output. The Cedar engine treats `@id` as having this exact semantic meaning, so the change aligns cedarpy with cedar-policy-cli — but if you'd prefer this be opt-in via a flag, happy to add one.