### PR TITLE
docs: add CHANGELOG.md and reference it in release process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+All notable changes to `cedarpy` are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+`cedarpy`'s version number tracks the upstream Cedar Policy engine major and minor version, with cedarpy-specific patch numbers. See the README for the Cedar engine ↔ `cedarpy` release mapping.
+
+## [Unreleased]
+
+### Added
+
+- `@id("...")` annotations on a policy or template now override the auto-generated `policy0`/`policy1`/... id, so `AuthzResult.diagnostics.reasons` and `ValidationError.policy_id` carry the human-readable id the user wrote in their policies ([#66](https://github.com/k9securityio/cedar-py/pull/66))
+
+### Changed
+
+- **Behavior change.** `is_authorized` / `is_authorized_batch` now return `Decision.NoDecision` with a diagnostic when given an invalid schema, instead of silently discarding the schema and returning a real `Allow` / `Deny`. The same path applies in `validate_policies` ([#65](https://github.com/k9securityio/cedar-py/pull/65))
+- **Behavior change.** Two policies with the same `@id` annotation now surface as `Decision.NoDecision` (in `is_authorized`) or `validation_passed=False` (in `validate_policies`) with a `"duplicate policy id"` diagnostic. Prior to [#66](https://github.com/k9securityio/cedar-py/pull/66), `@id` annotations were ignored entirely, so duplicates were inert ([#66](https://github.com/k9securityio/cedar-py/pull/66))
+
+## [4.8.1] - 2026-04-22
+
+Dependency update release. No functional or API changes — Cedar Policy engine version is unchanged (still v4.8.2).
+
+### Security
+
+- Bump `pytest` 7.4.0 → 9.0.3 — [CVE-2025-71176](https://nvd.nist.gov/vuln/detail/CVE-2025-71176) ([#41](https://github.com/k9securityio/cedar-py/pull/41))
+- Bump `wheel` 0.40.0 → 0.47.0 — [CVE-2026-24049](https://nvd.nist.gov/vuln/detail/CVE-2026-24049) ([#41](https://github.com/k9securityio/cedar-py/pull/41))
+- Bump `time` 0.3.37 → 0.3.47 — [CVE-2026-25727](https://nvd.nist.gov/vuln/detail/CVE-2026-25727) ([#42](https://github.com/k9securityio/cedar-py/pull/42))
+- Bump `keccak` 0.1.5 → 0.1.6 — [GHSA-3288-p39f-rqpv](https://github.com/advisories/GHSA-3288-p39f-rqpv) ([#42](https://github.com/k9securityio/cedar-py/pull/42))
+
+### Changed
+
+- Removed the stale `rustix = "~0.37.25"` pin; `rustix` is now governed by the transitive dep graph ([#43](https://github.com/k9securityio/cedar-py/pull/43))
+
+### Build & supply chain
+
+- Switched PyPI publishing from a long-lived API token to **PyPI Trusted Publishing** (OIDC), with a protected `pypi-release` deployment environment requiring maintainer approval. All wheels and the sdist for this release ship with SLSA build-provenance attestations ([#59](https://github.com/k9securityio/cedar-py/pull/59))
+- Added a Dependabot cooldown policy (7 days for minor/patch bumps, 14 for majors) to reduce exposure to newly-published compromised releases ([#44](https://github.com/k9securityio/cedar-py/pull/44), [#45](https://github.com/k9securityio/cedar-py/pull/45))
+- Disabled Dependabot version-update PRs; security-update PRs remain active ([#60](https://github.com/k9securityio/cedar-py/pull/60))
+
+## [4.8.0] - 2025-12-17
+
+### Changed
+
+- **Potentially breaking.** Updated the Cedar Policy engine to v4.8.2. `format_policies()` output has changed: the Cedar 4.8 formatter emits dot notation instead of bracket notation ([#38](https://github.com/k9securityio/cedar-py/pull/38) — thanks [@Iamrodos](https://github.com/Iamrodos))
+
+### Added
+
+- Performance regression test suite built on `pytest-benchmark` ([#39](https://github.com/k9securityio/cedar-py/pull/39))
+
+[Unreleased]: https://github.com/k9securityio/cedar-py/compare/v4.8.1...HEAD
+[4.8.1]: https://github.com/k9securityio/cedar-py/compare/v4.8.0...v4.8.1
+[4.8.0]: https://github.com/k9securityio/cedar-py/compare/v4.7.2...v4.8.0

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -22,11 +22,14 @@ git checkout main && git pull
 git checkout -b release/X.Y.Z
 ```
 
-Update three files:
+Update four files:
 
 - `Cargo.toml` — bump the `version` field (line 5)
 - `README.md` — update the `cedarpy release` cell in the compatibility table
 - `Cargo.lock` — regenerate by running `cargo build`
+- `CHANGELOG.md` — promote the `[Unreleased]` section to a new `[X.Y.Z] - YYYY-MM-DD` heading. Add a fresh empty `[Unreleased]` block above it, and add the new comparison link in the footer references (and update the `[Unreleased]` link to `vX.Y.Z...HEAD`)
+
+If `CHANGELOG.md`'s `[Unreleased]` section is thin or missing entries that should be there, fill them in from `git log v<previous>..main` before promoting it. Contributors are expected to update `[Unreleased]` in their PRs, but this is the maintainer's last chance to catch gaps.
 
 Commit with a message whose body is the draft release notes:
 
@@ -74,16 +77,20 @@ Confirm at https://pypi.org/project/cedarpy/X.Y.Z/ that:
 
 ### 5. Publish the GitHub Release
 
+The release notes are the version's section from `CHANGELOG.md`. Extract that section, then publish:
+
 ```bash
 gh release create vX.Y.Z --title "cedarpy vX.Y.Z" --notes-file <path-to-notes>
 ```
 
-Release notes should cover:
+If editorial polish is needed for the GitHub-rendered version (e.g. an opening paragraph, contributor thanks, a `Full Changelog: <previous-tag>...vX.Y.Z` link at the bottom), make those edits in the release notes only — do not re-edit `CHANGELOG.md`. The two are intentionally similar but the changelog is the durable, in-repo record while the release notes are the GitHub-rendered presentation.
+
+`CHANGELOG.md` should already cover:
 
 - Security fixes (with CVE / advisory IDs)
 - Cedar Policy engine version change, if any
 - Build / supply-chain changes
-- `Full Changelog: <previous-tag>...vX.Y.Z` link
+- Behavior changes called out under `Changed`
 
 ## Rollback
 


### PR DESCRIPTION
## Summary
- Adds `CHANGELOG.md` at the repo root in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format, backfilled to v4.8.0
- Updates `docs/release-process.md` to reference the changelog in the release flow

## CHANGELOG.md content
- **`[Unreleased]`** captures changes merged since v4.8.1:
  - `Added`: `@id("...")` annotation support (#66)
  - `Changed`: two behavior changes flagged with bold `Behavior change.` labels — invalid-schema `NoDecision` (#65) and duplicate-`@id` `NoDecision` (#66)
- **`[4.8.1] - 2026-04-22`** — sourced from the v4.8.1 GitHub Release with the `rustix` pin removal moved to `Changed` per Keep a Changelog conventions
- **`[4.8.0] - 2025-12-17`** — sourced from the v4.8.0 GitHub Release (Cedar engine v4.8.2, perf test suite)
- v4.7.x and earlier are intentionally not backfilled
- Documentation-only / internal-only changes are intentionally omitted

## docs/release-process.md changes
- **Step 1** (release PR) now lists `CHANGELOG.md` as the fourth file to update — promote `[Unreleased]` to a versioned section and add a fresh empty `[Unreleased]` above it
- **Step 5** (publish GitHub Release) now says to use the version's changelog section as the release-notes source. Editorial polish (opening paragraph, contributor thanks, `Full Changelog` link) goes on the release-notes side only — the changelog stays as the durable in-repo record

## Test plan
- [ ] CI green on the PR (no functional changes — just docs)
- [ ] On the next release, follow the updated step 1 to promote `[Unreleased]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
