### PR TITLE
fix: make @id annotation resolution opt-in via resolve_policy_ids_from_annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- `@id("...")` annotations on a policy or template now override the auto-generated `policy0`/`policy1`/... id, so `AuthzResult.diagnostics.reasons` and `ValidationError.policy_id` carry the human-readable id the user wrote in their policies ([#66](https://github.com/k9securityio/cedar-py/pull/66))
+- New optional parameter `resolve_policy_ids_from_annotations` on `is_authorized`, `is_authorized_batch`, and `validate_policies`. When `True`, `@id("...")` annotations on a policy or template override cedar's auto-generated `policy0`/`policy1`/... ids in `AuthzResult.diagnostics.reasons` and `ValidationError.policy_id`. Defaults to `False` because resolving annotations carries a per-call cost proportional to the number of policies (cedar's `PolicySet` is rebuilt with the renamed ids); callers who want the human-readable ids opt in explicitly. Resolves [#68](https://github.com/k9securityio/cedar-py/issues/68)
 
 ### Changed
 
 - **Behavior change.** `is_authorized` / `is_authorized_batch` now return `Decision.NoDecision` with a diagnostic when given an invalid schema, instead of silently discarding the schema and returning a real `Allow` / `Deny`. The same path applies in `validate_policies` ([#65](https://github.com/k9securityio/cedar-py/pull/65))
-- **Behavior change.** Two policies with the same `@id` annotation now surface as `Decision.NoDecision` (in `is_authorized`) or `validation_passed=False` (in `validate_policies`) with a `"duplicate policy id"` diagnostic. Prior to [#66](https://github.com/k9securityio/cedar-py/pull/66), `@id` annotations were ignored entirely, so duplicates were inert ([#66](https://github.com/k9securityio/cedar-py/pull/66))
+- **Behavior change.** Two policies with the same `@id` annotation now surface as `Decision.NoDecision` (in `is_authorized`) or `validation_passed=False` (in `validate_policies`) with a `"duplicate policy id"` diagnostic — but only when `resolve_policy_ids_from_annotations=True`. With the default, duplicate `@id` annotations are inert, matching the pre-`@id`-feature behavior ([#66](https://github.com/k9securityio/cedar-py/pull/66))
 
 ## [4.8.1] - 2026-04-22
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,9 @@ Project-specific guidance for Claude Code sessions working in `cedar-py`.
 - **Unit tests:** `pytest` (discovers `tests/unit/`)
 - **Integration tests:** `make integration-tests` — pulls the `third_party/cedar-integration-tests` git submodule
 - **Benchmarks:** `make benchmark-compare`. Do NOT refresh `tests/benchmark/results/baseline.json` for routine dep updates — only when performance-relevant code changes.
+  - **Build mode is debug.** `make benchmark-compare` runs `maturin develop` (debug). The committed `baseline.json` was also recorded in debug mode. Do NOT change one without the other — debug-mode runs are ~8× slower than release-mode runs, so a release-mode run trivially "passes" against the debug baseline. Tracked in #69.
+  - **Single-run benchmarks are very noisy.** Run-to-run mean swings of 30–50 percentage points on tail outliers are normal — the same code can fail one run and pass the next. For any meaningful regression analysis, run N≥5 times and take **medians**, not single-run means. The `out/v4.8.2-bisect/` directory has a working aggregator (`aggregate.py`) and runner (`run.sh`) that demonstrate the pattern. #69 tracks productizing this.
+  - The release process (`docs/release-process.md`) requires `make benchmark-compare` before opening a release PR. If a single run reports a regression, run it 4 more times and check the medians before declaring a real issue.
 
 ## Dependency management
 
@@ -46,7 +49,18 @@ Documented in `docs/release-process.md`. Highlights:
 - **Branch naming:** conventional-commits style (`feat/`, `fix/`, `chore/`, `docs/`, `release/<version>`). **Do not** prefix branches with internal Jira keys (e.g. `CLOUD-####`) — this is an open-source repo.
 - **Commit messages and PR descriptions:** same rule — keep internal Jira keys out. Internal tracking is one-way (the Jira issue links out to GitHub PRs, not the other way).
 - **Cedar engine ↔ cedarpy mapping:** README has a table. Update the cedarpy column on every release.
+- **Editing contributor PRs as maintainer:** when "Allow edits from maintainers" is checked on a fork-based PR, push directly for trivial changes (typos, error-message wording, release-note tweaks), and use a review comment for substantive logic edits. Always leave a PR comment summarizing what you pushed and why — name the SHA so the contributor can locate the change without hunting.
+
+## Cedar API gotchas worth knowing
+
+- **`Policy::clone()` is not cheap.** `cedar_policy::ast::Policy` has an `Arc<Template>` internally, but the public `Policy` type also carries a separate `LosslessPolicy` representation that gets cloned alongside the AST. Plus, `PolicySet::add()` does its own validation + indexing per insert. So rebuilding a `PolicySet` (e.g. to rename policies) costs in proportion to `|policies|` — measurable at ~15% on complex-policy workloads in release mode (much more in debug). Don't put per-call `PolicySet` rebuilds on the hot path. (#68 was this exact mistake; the fix made `@id` rename opt-in via the `resolve_policy_ids_from_annotations` parameter.)
+- **`@id` annotations are not parser directives** — they're metadata. `PolicySet::from_str` assigns auto-ids (`policy0`, `policy1`, ...) regardless of `@id` content. Honoring `@id` requires either rebuilding the `PolicySet` (current implementation, opt-in) or translating ids at result-construction time (alternative drafted but not adopted).
 
 ## Follow-on work to be aware of
 
 - **GitHub Actions consolidation (GH issue #62):** 6 actions in `CI.yml` are on outdated major versions (e.g. `actions/upload-artifact@v4` when v7 is current). Planned approach: one consolidated PR pinning all actions to commit SHAs with tag comments. Defer until there's time to review the cross-major changelogs, and do not bundle with a release.
+- **Benchmark process improvements (GH issue #69):** four items: add a benchmark variant exercising `resolve_policy_ids_from_annotations=True`; switch `make benchmark` targets to release builds; refresh `baseline.json` to a release-mode recording at the post-#68 tip; productize the multi-run aggregation pattern (currently in `out/v4.8.2-bisect/`). Items 2+3 must move together. Important pre-release-tooling work — until #69 lands, treat single-run regression alarms with skepticism and re-run N=5+ for medians.
+
+## Out-of-tree working artifacts
+
+The `out/` directory at the repo root holds local-only working artifacts (analysis docs, captured tool output, draft PR/issue text, benchmark JSONs from ad-hoc bisects). Currently NOT in `.gitignore`. Treat its contents as scratch space — useful for the maintainer running an investigation, not for the public repo. Don't commit `out/` files unless explicitly intended.

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ integration-tests: submodules
 release:
 	@echo Building a release
 	set -e ;\
-	maturin build ;\
+	maturin build --release ;\
 	pytest
 
 # Performance benchmark targets

--- a/cedarpy/__init__.py
+++ b/cedarpy/__init__.py
@@ -116,7 +116,8 @@ def is_authorized(request: dict,
                   policies: str,
                   entities: Union[str, List[dict]],
                   schema: Union[str, dict, None] = None,
-                  verbose: bool = False) -> AuthzResult:
+                  verbose: bool = False,
+                  resolve_policy_ids_from_annotations: bool = False) -> AuthzResult:
     """Evaluate whether the request is authorized given the parameters.
 
     :param request is a Cedar-style request object containing a principal, action, resource, and (optional) context;
@@ -126,6 +127,10 @@ def is_authorized(request: dict,
     include in the evaluation
     :param schema (optional) dictionary or json-formatted string containing the Cedar schema
     :param verbose (optional) boolean determining whether to enable verbose logging output within the library
+    :param resolve_policy_ids_from_annotations (optional, default False) when True, ``@id("...")`` annotations on
+    policies and templates override cedar's auto-generated ``policy0``/``policy1``/... ids in
+    ``AuthzResult.diagnostics.reasons``. Opt-in because this carries a measurable per-call cost
+    proportional to the number of policies (the underlying ``PolicySet`` is rebuilt with the renamed ids).
 
     :returns an AuthzResult
 
@@ -134,14 +139,16 @@ def is_authorized(request: dict,
                                policies=policies,
                                entities=entities,
                                schema=schema,
-                               verbose=verbose)[0]
+                               verbose=verbose,
+                               resolve_policy_ids_from_annotations=resolve_policy_ids_from_annotations)[0]
 
 
 def is_authorized_batch(requests: List[dict],
                         policies: str,
                         entities: Union[str, List[dict]],
                         schema: Union[str, dict, None] = None,
-                        verbose: bool = False) -> List[AuthzResult]:
+                        verbose: bool = False,
+                        resolve_policy_ids_from_annotations: bool = False) -> List[AuthzResult]:
     """Evaluate whether a batch of requests are authorized given the other parameters.  Each request is evaluated
     independently and results in an AuthzResult per request.
 
@@ -152,6 +159,10 @@ def is_authorized_batch(requests: List[dict],
     include in the evaluation
     :param schema (optional) dictionary or json-formatted string containing the Cedar schema
     :param verbose (optional) boolean determining whether to enable verbose logging output within the library
+    :param resolve_policy_ids_from_annotations (optional, default False) when True, ``@id("...")`` annotations on
+    policies and templates override cedar's auto-generated ``policy0``/``policy1``/... ids in each
+    ``AuthzResult.diagnostics.reasons``. Opt-in because this carries a measurable per-call cost
+    proportional to the number of policies.
 
     :returns a list of AuthzResults, in same order as the requests
 
@@ -182,7 +193,9 @@ def is_authorized_batch(requests: List[dict],
         elif isinstance(schema, dict):
             schema = json.dumps(schema)
 
-    authz_result_strs: List[str] = _internal.is_authorized_batch(requests_local, policies, entities, schema, verbose)
+    authz_result_strs: List[str] = _internal.is_authorized_batch(
+        requests_local, policies, entities, schema, verbose, resolve_policy_ids_from_annotations
+    )
     authz_result_objs: List[dict] = []
 
     for authz_result_str in authz_result_strs:
@@ -232,7 +245,8 @@ def policies_from_json_str(policies: str) -> str:
 
 
 def validate_policies(policies: str,
-                      schema: Union[str, dict]) -> ValidationResult:
+                      schema: Union[str, dict],
+                      resolve_policy_ids_from_annotations: bool = False) -> ValidationResult:
     """Validate Cedar policies against a schema.
 
     This function checks that policies are valid according to the provided schema,
@@ -241,6 +255,10 @@ def validate_policies(policies: str,
 
     :param policies: Cedar policies as a string
     :param schema: Cedar schema (JSON dict, JSON string, or Cedar schema string)
+    :param resolve_policy_ids_from_annotations: (optional, default False) when True,
+        ``@id("...")`` annotations on policies and templates override cedar's auto-generated
+        ``policy0``/``policy1``/... ids in ``ValidationError.policy_id``. Opt-in because this
+        carries a measurable per-call cost proportional to the number of policies.
 
     :returns: ValidationResult with validation_passed boolean and list of errors
 
@@ -255,6 +273,6 @@ def validate_policies(policies: str,
     if isinstance(schema, dict):
         schema = json.dumps(schema)
 
-    result_str = _internal.validate_policies(policies, schema)
+    result_str = _internal.validate_policies(policies, schema, resolve_policy_ids_from_annotations)
     result_dict = json.loads(result_str)
     return ValidationResult(result_dict)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,26 +90,29 @@ impl RequestArgs {
 }
 
 #[pyfunction]
-#[pyo3(signature = (request, policies, entities, schema = None, verbose = false,))]
+#[pyo3(signature = (request, policies, entities, schema = None, verbose = false, resolve_policy_ids_from_annotations = false))]
 fn is_authorized(request: HashMap<String, String>,
                  policies: String,
                  entities: String,
                  schema: Option<String>,
-                 verbose: Option<bool>)
+                 verbose: Option<bool>,
+                 resolve_policy_ids_from_annotations: Option<bool>)
                  -> String {
-    is_authorized_batch(vec![request], policies, entities, schema, verbose)[0].clone()
+    is_authorized_batch(vec![request], policies, entities, schema, verbose, resolve_policy_ids_from_annotations)[0].clone()
 }
 
 #[pyfunction]
-#[pyo3(signature = (requests, policies, entities, schema = None, verbose = false,))]
+#[pyo3(signature = (requests, policies, entities, schema = None, verbose = false, resolve_policy_ids_from_annotations = false))]
 fn is_authorized_batch(requests: Vec<HashMap<String, String>>,
                        policies: String,
                        entities: String,
                        schema: Option<String>,
-                       verbose: Option<bool>)
+                       verbose: Option<bool>,
+                       resolve_policy_ids_from_annotations: Option<bool>)
                        -> Vec<String> {
     // CLI AuthorizeArgs: https://github.com/cedar-policy/cedar/blob/main/cedar-policy-cli/src/lib.rs#L183
     let verbose = verbose.unwrap_or(false);
+    let resolve_ids = resolve_policy_ids_from_annotations.unwrap_or(false);
     if verbose {
         //println!("requests: {}", requests);
         println!("policies: {}", policies);
@@ -123,14 +126,20 @@ fn is_authorized_batch(requests: Vec<HashMap<String, String>>,
     // parse policies
     let t_parse_policies = Instant::now();
     let policy_set = match PolicySet::from_str(&policies) {
-        Ok(pset) => match rename_from_id_annotation(pset) {
-            Ok(renamed) => renamed,
-            Err((_policy_id, e)) => {
-                println!("{:#}", e);
-                errs.push(e);
-                PolicySet::new()
+        Ok(pset) => {
+            if resolve_ids {
+                match rename_from_id_annotation(pset) {
+                    Ok(renamed) => renamed,
+                    Err((_policy_id, e)) => {
+                        println!("{:#}", e);
+                        errs.push(e);
+                        PolicySet::new()
+                    }
+                }
+            } else {
+                pset
             }
-        },
+        }
         Err(parse_errors) => {
             let err_message = format!("policy parse errors:\n{:#}",
                                       parse_errors.to_string());
@@ -474,23 +483,30 @@ fn rename_from_id_annotation(ps: PolicySet) -> Result<PolicySet, (String, Error)
 
 /// Validate Cedar policies against a schema and return a JSON result.
 #[pyfunction]
-#[pyo3(signature = (policies, schema))]
-fn validate_policies(policies: String, schema: String) -> String {
+#[pyo3(signature = (policies, schema, resolve_policy_ids_from_annotations = false))]
+fn validate_policies(policies: String, schema: String, resolve_policy_ids_from_annotations: Option<bool>) -> String {
+    let resolve_ids = resolve_policy_ids_from_annotations.unwrap_or(false);
     // Parse policies
     let policy_set = match PolicySet::from_str(&policies) {
-        Ok(pset) => match rename_from_id_annotation(pset) {
-            Ok(renamed) => renamed,
-            Err((policy_id, e)) => {
-                let result = ValidationResultSer {
-                    validation_passed: false,
-                    errors: vec![ValidationErrorSer {
-                        policy_id,
-                        error: format!("Policy id annotation error: {}", e),
-                    }],
-                };
-                return serde_json::to_string(&result).unwrap();
+        Ok(pset) => {
+            if resolve_ids {
+                match rename_from_id_annotation(pset) {
+                    Ok(renamed) => renamed,
+                    Err((policy_id, e)) => {
+                        let result = ValidationResultSer {
+                            validation_passed: false,
+                            errors: vec![ValidationErrorSer {
+                                policy_id,
+                                error: format!("Policy id annotation error: {}", e),
+                            }],
+                        };
+                        return serde_json::to_string(&result).unwrap();
+                    }
+                }
+            } else {
+                pset
             }
-        },
+        }
         Err(parse_errors) => {
             let result = ValidationResultSer {
                 validation_passed: false,

--- a/tests/unit/test_authorize.py
+++ b/tests/unit/test_authorize.py
@@ -522,9 +522,39 @@ class AuthorizeTestCase(unittest.TestCase):
             "context": {},
         }
 
-        authz_result: AuthzResult = is_authorized(request, policies, self.entities)
+        authz_result: AuthzResult = is_authorized(
+            request, policies, self.entities,
+            resolve_policy_ids_from_annotations=True,
+        )
         self.assertEqual(Decision.Allow, authz_result.decision)
         self.assertEqual(["alice_can_view"], authz_result.diagnostics.reasons)
+
+    def test_id_annotation_ignored_by_default(self):
+        # `@id` annotations are ignored unless the caller opts in via
+        # `resolve_policy_ids_from_annotations=True`. With the default
+        # (False), the annotation has no effect on diagnostics.reasons,
+        # which contains cedar's auto-generated id (e.g., "policy0").
+        policies = """
+            @id("alice_can_view")
+            permit(
+                principal == User::"alice",
+                action == Action::"view",
+                resource
+            );
+        """.strip()
+
+        request = {
+            "principal": 'User::"alice"',
+            "action": 'Action::"view"',
+            "resource": 'Photo::"alice_w2.jpg"',
+            "context": {},
+        }
+
+        authz_result: AuthzResult = is_authorized(request, policies, self.entities)
+        self.assertEqual(Decision.Allow, authz_result.decision)
+        # Default: cedar's auto-id, not the @id-annotation value
+        self.assertNotIn("alice_can_view", authz_result.diagnostics.reasons)
+        self.assertEqual(1, len(authz_result.diagnostics.reasons))
 
     def test_id_annotation_mixed_with_unannotated_policies(self):
         # Mix annotated + un-annotated policies. Annotated policy keeps its
@@ -556,19 +586,26 @@ class AuthorizeTestCase(unittest.TestCase):
             "context": {},
         }
 
-        alice_result: AuthzResult = is_authorized(alice_request, policies, self.entities)
+        alice_result: AuthzResult = is_authorized(
+            alice_request, policies, self.entities,
+            resolve_policy_ids_from_annotations=True,
+        )
         self.assertEqual(Decision.Allow, alice_result.decision)
         self.assertEqual(["alice_view"], alice_result.diagnostics.reasons)
 
-        bob_result: AuthzResult = is_authorized(bob_request, policies, self.entities)
+        bob_result: AuthzResult = is_authorized(
+            bob_request, policies, self.entities,
+            resolve_policy_ids_from_annotations=True,
+        )
         self.assertEqual(Decision.Allow, bob_result.decision)
         # un-annotated policy keeps cedar's default id (some "policyN")
         self.assertEqual(1, len(bob_result.diagnostics.reasons))
         self.assertNotEqual("alice_view", bob_result.diagnostics.reasons[0])
 
     def test_id_annotation_duplicate_returns_no_decision(self):
-        # Two policies that resolve to the same @id are a configuration error;
-        # surface as NoDecision + diagnostic rather than silently dropping one.
+        # When resolve_policy_ids_from_annotations=True, two policies that
+        # resolve to the same @id are a configuration error: surface as
+        # NoDecision + diagnostic rather than silently dropping one.
         policies = """
             @id("dup")
             permit(
@@ -591,7 +628,10 @@ class AuthorizeTestCase(unittest.TestCase):
             "context": {},
         }
 
-        authz_result: AuthzResult = is_authorized(request, policies, self.entities)
+        authz_result: AuthzResult = is_authorized(
+            request, policies, self.entities,
+            resolve_policy_ids_from_annotations=True,
+        )
         self.assertEqual(Decision.NoDecision, authz_result.decision)
         self.assertEqual(1, len(authz_result.diagnostics.errors))
         self.assertIn("duplicate policy id", authz_result.diagnostics.errors[0].lower())

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -153,7 +153,29 @@ class ValidatePoliciesTestCase(unittest.TestCase):
         self.assertIn("validation_passed=True", repr_str)
 
     def test_id_annotation_renames_policy_id_in_validation_errors(self):
-        """Validation errors should report the @id-annotated policy id."""
+        """When `resolve_policy_ids_from_annotations=True`, validation errors
+        should report the @id-annotated policy id."""
+        policy_with_id = """
+            @id("alice_view_bad_entity")
+            permit(
+                principal == Usr::"alice",
+                action == Action::"view",
+                resource
+            );
+        """
+        result = validate_policies(
+            policy_with_id, self.schema,
+            resolve_policy_ids_from_annotations=True,
+        )
+
+        self.assertFalse(result.validation_passed)
+        self.assertGreater(len(result.errors), 0)
+        self.assertEqual("alice_view_bad_entity", result.errors[0].policy_id)
+
+    def test_id_annotation_ignored_in_validation_errors_by_default(self):
+        """With the default (`resolve_policy_ids_from_annotations=False`),
+        validation errors carry cedar's auto-generated PolicyId, not the
+        @id-annotated value."""
         policy_with_id = """
             @id("alice_view_bad_entity")
             permit(
@@ -166,29 +188,14 @@ class ValidatePoliciesTestCase(unittest.TestCase):
 
         self.assertFalse(result.validation_passed)
         self.assertGreater(len(result.errors), 0)
-        self.assertEqual("alice_view_bad_entity", result.errors[0].policy_id)
+        # Default: cedar's auto-id is surfaced, not the annotation value
+        self.assertNotEqual("alice_view_bad_entity", result.errors[0].policy_id)
 
     def test_validate_with_duplicate_policy_id_annotations(self):
-        """Document the library's behavior when a caller declares two
-        policies with the same @id annotation.
-
-        Pre-PR-66, cedarpy ignored @id entirely, so duplicate annotations
-        were inert — validation proceeded against whatever cedar's
-        auto-generated ids were. After PR-66, duplicates are surfaced as a
-        validation failure.
-
-        The current diagnostic returned by validate_policies:
-          - validation_passed:  False
-          - errors:             single ValidationError
-          - errors[0].policy_id:  the offending policy's pre-rename id
-                                  (e.g. 'policy1' for the second of two
-                                  duplicates), so callers can locate the
-                                  conflict in their input
-          - errors[0].error:    starts with 'Policy id annotation error:'
-                                and contains 'duplicate policy id'
-
-        This test exists to make any future change to that behavior
-        deliberate and visible in diffs.
+        """When `resolve_policy_ids_from_annotations=True` and two policies
+        declare the same @id, the rename is surfaced as a validation failure
+        with the offending policy's pre-rename id (e.g. 'policy1' for the
+        second of two duplicates).
         """
         policies = """
             @id("dup")
@@ -204,7 +211,10 @@ class ValidatePoliciesTestCase(unittest.TestCase):
                 resource
             );
         """
-        result = validate_policies(policies, self.schema)
+        result = validate_policies(
+            policies, self.schema,
+            resolve_policy_ids_from_annotations=True,
+        )
 
         self.assertFalse(result.validation_passed)
         self.assertEqual(1, len(result.errors))


### PR DESCRIPTION
## Summary

Resolves #68. Makes `@id` annotation resolution opt-in via a new `resolve_policy_ids_from_annotations` parameter on `is_authorized`, `is_authorized_batch`, and `validate_policies`. The parameter defaults to `False`, restoring v4.8.0 performance on the default code path.

Also fixes a separate latent issue with the `make release` Makefile target (was producing debug wheels despite the name), and updates `CLAUDE.md` with cedar-API gotchas and benchmark-process lessons learned during the investigation.

## Commits

1. **`fix: make @id annotation resolution opt-in via resolve_policy_ids_from_annotations`** — the perf fix proper
2. **`docs: capture cedar API gotchas and benchmark process lessons in CLAUDE.md`** — guidance for future maintainers / AI assistants
3. **`fix: build release-mode wheel in 'make release' target`** — local Makefile bug fix; PyPI publishing was already correct

## Why

PR #66 introduced an unconditional `PolicySet` rebuild on every `is_authorized*` / `validate_policies` call to honor `@id` annotations. The rebuild cost ~15% on complex-policy workloads in release mode (~30% in debug), even when no policy used `@id` at all — because cedar's `Policy::clone()` and `PolicySet::add()` do real work proportional to `|policies|`.

This was caught when preparing the v4.8.2 release: `make benchmark-compare` failed loudly on multiple workloads. A real-world downstream test (running cedarpy in a dependent product) confirmed the production-mode regression.

## Performance

N=5 release-mode median, vs v4.8.0 baseline (microseconds):

| Benchmark | v4.8.0 | PR #66 (always rename) | This PR (default off) |
|---|---|---|---|
| `test_complex_policy` | 286 | 329 (**+14.9%**) | **275 (-3.8%)** |
| `test_simple_policy_deny` | 152 | 153 (+1.1%) | **148 (-2.5%)** |
| `test_medium_policy` | 216 | 213 (-1.0%) | **191 (-11.2%)** |
| `test_small_entity_set` | 188 | 213 (+13.3%) | **190 (+1.1%)** |
| `test_batch_complex_policy` | 1234 | 1332 (+8.0%) | **1242 (+0.6%)** |

Default-off lands within v4.8.0's noise floor on every benchmark. Per `out/v4.8.2-bisect/summary.md` (full bisect data, 8 states × 5 runs × 2 build modes).

## API change

```python
authz_result = is_authorized(
    request, policies, entities,
    schema=schema,
    resolve_policy_ids_from_annotations=False,  # default; cedar auto-ids in reasons
)

# Opt-in: @id annotations override cedar auto-ids in diagnostics.reasons
authz_result = is_authorized(
    request, policies, entities,
    resolve_policy_ids_from_annotations=True,
)
```

Same parameter on `is_authorized_batch` and `validate_policies`.

## Behavior change vs current `main`

Anyone who landed PR #66 on `main` and started using `@id` annotations expecting them to surface in `AuthzResult.diagnostics.reasons` will need to pass `resolve_policy_ids_from_annotations=True` going forward. PR #66 has not been released to PyPI yet (it's in `[Unreleased]` of `CHANGELOG.md`), so this affects no shipped users — the default-False landed before the public release.

The CHANGELOG entry has been updated to reflect the opt-in design.

## Test plan

- [x] `pytest tests/unit` — 60 passed (was 55 before this PR)
- [x] `make integration-tests` — 69 passed, 5 skipped
- [x] `make benchmark-compare` — within v4.8.0 noise floor (some single-run failures expected per #69; medians across 5 runs are clean)
- [x] Validated downstream: cedarpy 4.8.2-pre wheel from this branch tested in a dependent product, no functional or performance regressions observed
- [ ] CI green on the PR

## Related

- Resolves #68
- Issue #69 tracks benchmark-process improvements (release-mode benchmarks, multi-run aggregation, refreshed baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
