### PR TITLE
release: bump version to 4.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [4.8.2] - 2026-05-12
+
 ### Added
 
 - **Behavior change.** `@id("...")` annotations on a policy now surface as the human-readable id in `AuthzResult.diagnostics.reasons` and `ValidationError.policy_id`, instead of the auto-generated `policy0`/`policy1`/... id. Annotations are inert in Cedar evaluation per the [Cedar docs](https://docs.cedarpolicy.com/policies/syntax-policy.html#term-parc-annotations); this is a labeling step on the response surface, not a rename of the underlying `PolicyId`. An `@id` with an empty value — either `@id("")` or value-less `@id` (which per the Cedar docs is equivalent to `@id("")`) — falls back to the parser-generated id, since an empty display id is unhelpful for logs and lookups ([#29](https://github.com/k9securityio/cedar-py/issues/29), [#74](https://github.com/k9securityio/cedar-py/issues/74), [#75](https://github.com/k9securityio/cedar-py/pull/75))
@@ -15,6 +17,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - **Behavior change.** `is_authorized` / `is_authorized_batch` now return `Decision.NoDecision` with a diagnostic when given an invalid schema, instead of silently discarding the schema and returning a real `Allow` / `Deny`. The same path applies in `validate_policies` ([#65](https://github.com/k9securityio/cedar-py/pull/65))
+
+### Fixed
+
+- `make release` now builds and tests a release-mode wheel. The target previously ran `maturin build` (which defaults to the dev/debug profile) and then ran pytest against whatever cedarpy was currently installed in the venv — neither half tested the wheel that would ship. PyPI artifacts were unaffected (CI already passed `--release`); this fixes locally-built wheels.
 
 ## [4.8.1] - 2026-04-22
 
@@ -47,6 +53,7 @@ Dependency update release. No functional or API changes — Cedar Policy engine 
 
 - Performance regression test suite built on `pytest-benchmark` ([#39](https://github.com/k9securityio/cedar-py/pull/39))
 
-[Unreleased]: https://github.com/k9securityio/cedar-py/compare/v4.8.1...HEAD
+[Unreleased]: https://github.com/k9securityio/cedar-py/compare/v4.8.2...HEAD
+[4.8.2]: https://github.com/k9securityio/cedar-py/compare/v4.8.1...v4.8.2
 [4.8.1]: https://github.com/k9securityio/cedar-py/compare/v4.8.0...v4.8.1
 [4.8.0]: https://github.com/k9securityio/cedar-py/compare/v4.7.2...v4.8.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "cedarpy"
-version = "4.8.1"
+version = "4.8.2"
 dependencies = [
  "anyhow",
  "cedar-policy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 # Maturin merges package metadata from pyproject.toml (preferred) and Cargo.toml
 # c.f. https://github.com/PyO3/maturin?tab=readme-ov-file#python-metadata
 name = "cedarpy"
-version = "4.8.1"
+version = "4.8.2"
 edition = "2021"
 readme = "README.md"
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <table>
 <thead><tr><th>Cedar Policy (engine) release</th><th>cedarpy release</th><th>cedarpy branch</th></tr></thead>
 <tbody>
-    <tr><td>v4.8.2</td><td>v4.8.1</td><td>main</td></tr>
+    <tr><td>v4.8.2</td><td>v4.8.2</td><td>main</td></tr>
     <tr><td>v4.7.2</td><td>v4.7.1</td><td>release/4.7.x</td></tr>
     <tr><td>v4.1.0</td><td>v4.1.0</td><td>release/4.1.x</td></tr>
     <tr><td>v2.2.0</td><td>v0.4.1</td><td>release/2.2.x</td></tr>


### PR DESCRIPTION
## Summary

Promotes `[Unreleased]` to `[4.8.2] - 2026-05-12` and bumps the package version. Cedar Policy engine version is unchanged (still v4.8.2).

## Highlights since v4.8.1

- **`@id` annotations surface as the human-readable id.** `AuthzResult.diagnostics.reasons` and `ValidationError.policy_id` now carry the `@id` value instead of the auto-generated `policy0`/`policy1`/... id (#74, #75). Annotations are inert in Cedar evaluation per the [Cedar docs](https://docs.cedarpolicy.com/policies/syntax-policy.html#term-parc-annotations); this is a labeling step on the response surface, not a rename of the underlying `PolicyId`. Empty `@id` values fall back to the parser-generated id.

- **Invalid schemas surface as diagnostics, not silent discards.** `is_authorized` / `is_authorized_batch` / `validate_policies` now return `Decision.NoDecision` (or `validation_passed=False`) with a diagnostic when given an invalid schema (#65).

- **`make release` builds and tests a release-mode wheel.** The target previously ran `maturin build` (dev profile) and ran pytest against whatever was installed in the venv — neither half tested the actual release wheel. PyPI artifacts were unaffected; this only fixed locally-built wheels.

## Performance

`test_complex_policy` median across the v4.8.0 → v4.8.2 arc (full table in `tests/benchmark/results/HISTORY.md`):

| State | Median (μs) | Δ vs v4.8.0 |
|---|---|---|
| v4.8.0 | 281 | — |
| PR #66 (rename-based `@id`) | 322 | +14.7% |
| main pre-fix | 323 | +14.9% |
| **PR #75 (Path B) — v4.8.2** | **279** | **-0.6%** |

## Test plan

- [x] `pytest tests/unit` — 62 passed
- [x] `make integration-tests` — 69 passed, 5 skipped
- [x] `make benchmark-compare` — medians within v4.8.0 noise floor (≤3%)
- [x] `make release` — builds release-mode wheel, force-reinstalls into venv, all unit tests pass against the wheel
- [x] Downstream commercial product tested against the local release-candidate wheel — passed
- [x] CI green across all platforms

## Files touched

- `Cargo.toml` — version 4.8.1 → 4.8.2
- `Cargo.lock` — regenerated via `cargo build`
- `README.md` — compatibility table: `cedarpy release` cell for Cedar v4.8.2 row
- `CHANGELOG.md` — `[Unreleased]` promoted to `[4.8.2] - 2026-05-12`; new empty `[Unreleased]` block; footer links updated
