### PR TITLE
release: bump version to 4.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [4.8.3] - 2026-05-13
+
 ### Changed
 
 - **Behavior change (partial revert of 4.8.2).** `AuthzResult.diagnostics.reasons` and `ValidationError.policy_id` once again surface the parser-generated `PolicyId` (e.g., `policy0`), restoring the 4.8.1 contract that was relied on for multi-tenant disambiguation. The `@id("...")` annotation value is now exposed in a parallel map keyed by the parser id: `Diagnostics.id_annotations_by_reason` and `ValidationResult.id_annotations_by_policy_id`. Entries are present whenever the policy declares an `@id` annotation, with the literal annotation value as the map value — so `@id("foo")` contributes `"foo"`, and `@id("")` / bare `@id` (which the Cedar docs define as equivalent to `@id("")`) contributes `""`. Policies with no `@id` annotation are omitted from the map. This keeps the 4.8.2 ergonomics gain (recover the `@id` label without rebuilding the policy set) while preventing identity collapse when two policies share the same `@id` ([#77](https://github.com/k9securityio/cedar-py/issues/77))
@@ -57,7 +59,8 @@ Dependency update release. No functional or API changes — Cedar Policy engine 
 
 - Performance regression test suite built on `pytest-benchmark` ([#39](https://github.com/k9securityio/cedar-py/pull/39))
 
-[Unreleased]: https://github.com/k9securityio/cedar-py/compare/v4.8.2...HEAD
+[Unreleased]: https://github.com/k9securityio/cedar-py/compare/v4.8.3...HEAD
+[4.8.3]: https://github.com/k9securityio/cedar-py/compare/v4.8.2...v4.8.3
 [4.8.2]: https://github.com/k9securityio/cedar-py/compare/v4.8.1...v4.8.2
 [4.8.1]: https://github.com/k9securityio/cedar-py/compare/v4.8.0...v4.8.1
 [4.8.0]: https://github.com/k9securityio/cedar-py/compare/v4.7.2...v4.8.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "cedarpy"
-version = "4.8.2"
+version = "4.8.3"
 dependencies = [
  "anyhow",
  "cedar-policy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 # Maturin merges package metadata from pyproject.toml (preferred) and Cargo.toml
 # c.f. https://github.com/PyO3/maturin?tab=readme-ov-file#python-metadata
 name = "cedarpy"
-version = "4.8.2"
+version = "4.8.3"
 edition = "2021"
 readme = "README.md"
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <table>
 <thead><tr><th>Cedar Policy (engine) release</th><th>cedarpy release</th><th>cedarpy branch</th></tr></thead>
 <tbody>
-    <tr><td>v4.8.2</td><td>v4.8.2</td><td>main</td></tr>
+    <tr><td>v4.8.2</td><td>v4.8.3</td><td>main</td></tr>
     <tr><td>v4.7.2</td><td>v4.7.1</td><td>release/4.7.x</td></tr>
     <tr><td>v4.1.0</td><td>v4.1.0</td><td>release/4.1.x</td></tr>
     <tr><td>v2.2.0</td><td>v0.4.1</td><td>release/2.2.x</td></tr>


### PR DESCRIPTION
Patch release fixing the behavior regression introduced in 4.8.2 (issue #77, fixed in PR #78).

## Changed

- **Behavior change (partial revert of 4.8.2).** `AuthzResult.diagnostics.reasons` and `ValidationError.policy_id` once again surface the parser-generated `PolicyId` (e.g., `policy0`), restoring the 4.8.1 contract that multi-tenant callers relied on for disambiguation. The `@id("...")` annotation value is now exposed in a parallel map keyed by the parser id: `Diagnostics.id_annotations_by_reason` and `ValidationResult.id_annotations_by_policy_id`. Entries are present whenever the policy declares an `@id` annotation, with the literal annotation value as the map value — so `@id("foo")` contributes `"foo"`, and `@id("")` / bare `@id` (which the Cedar docs define as equivalent to `@id("")`) contributes `""`. Policies with no `@id` annotation are omitted from the map. (#77, #78)

Cedar Policy engine version is unchanged at v4.8.2.

## Release checklist

- [x] `Cargo.toml` version bumped to 4.8.3
- [x] `Cargo.lock` regenerated
- [x] `README.md` compatibility table updated (cedarpy column → v4.8.3)
- [x] `CHANGELOG.md` `[Unreleased]` promoted to `[4.8.3] - 2026-05-13`, new empty `[Unreleased]` added, footer links updated
- [x] release-mode build clean, `pytest tests/unit` passes (64 + 2 subtests)
- [x] `make benchmark-compare` on `main` (post-#78 merge): no regression vs baseline

## Test plan

- [x] CI green across all platforms (Linux x86_64/aarch64, macOS x86_64/aarch64, Windows x64)

After merge: tag `v4.8.3` on `main` to trigger the release job, then approve the `pypi-release` deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
