### PR TITLE
feat(benchmark): median-of-N regression gate for make benchmark-compare (#69 goal 3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ docs/_build/
 
 # Benchmark results (machine-specific, should not be committed)
 tests/benchmark/results/out
+tests/benchmark/results/current/
 
 # Local scratch — top-level out/ holds ad-hoc working artifacts (analysis
 # notes, captured tool output, draft PR/issue text, benchmark JSONs from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- `make benchmark-compare` now runs N=5 release-mode benchmarks at HEAD and gates on median Δ vs `tests/benchmark/results/baseline.json`, replacing the prior single pytest-benchmark run with `--benchmark-compare-fail=median:5%,mean:15%`. The `mean` threshold has been dropped — a single tail outlier could trip a passing run, and the N=5 median is the stable signal. Per-run JSONs land in `tests/benchmark/results/current/` (gitignored). Override the run count via `BENCHMARK_RUNS=N` ([#69](https://github.com/k9securityio/cedar-py/issues/69))
+
 ## [4.8.3] - 2026-05-13
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Project-specific guidance for Claude Code sessions working in `cedar-py`.
 - **Unit tests:** `pytest` (discovers `tests/unit/`)
 - **Integration tests:** `make integration-tests` — pulls the `third_party/cedar-integration-tests` git submodule
 - **Benchmarks:**
-  - `make benchmark-compare` for single-run regression check vs `tests/benchmark/results/baseline.json`. Do NOT refresh the baseline for routine dep updates — only for performance-relevant code changes.
+  - `make benchmark-compare` runs N=5 release-mode benchmarks at HEAD and gates on **median Δ** vs `tests/benchmark/results/baseline.json` (per-benchmark `stats.median`). Override the run count with `BENCHMARK_RUNS=N`. The previous `mean:15%` threshold was dropped — median-only gating per #69 goal 3. Per-run JSONs land in `tests/benchmark/results/current/` (gitignored, wiped each invocation). Do NOT refresh the baseline for routine dep updates — only for performance-relevant code changes.
   - `make benchmark-history` for release-mode multi-run capture across the historical commits listed in `tests/benchmark/capture_history.sh`. Outputs land in `tests/benchmark/results/history/<state>.json` (per-commit summary stats) and `tests/benchmark/results/HISTORY.md` (rendered cross-state table). The script does a `git checkout` per state and restores the starting branch on exit.
   - See `tests/benchmark/README.md` for the workflow, default run count (N=5) and why we landed there, the `STATES` format (`<save_prefix>:<git_ref>:<description>`, all required), and the `states-manifest.json` plumbing between the runner and aggregator.
 

--- a/Makefile
+++ b/Makefile
@@ -67,21 +67,14 @@ benchmark-save:
 
 .PHONY: benchmark-compare
 benchmark-compare:
-	# note: tried failing on stddev and max deviations, but the tail seems to be too noisy.
-	# observed repeated max+stddev failures on back to back runs on the same machine
-	# so skipped those assertions and relaxed mean regression threshold, which is a little noisy on batches.
-
-	@echo Running benchmarks and comparing with baseline
+	@echo Running N benchmark runs at HEAD and comparing median Δ against baseline
 	@if [ ! -f $(BENCHMARK_RESULTS_DIR)/baseline.json ]; then \
-		echo "Error: $(BENCHMARK_RESULTS_DIR)/baseline.json not found. Sym-link $(BENCHMARK_RESULTS_DIR)/baseline.json to the current baseline results"; \
+		echo "Error: $(BENCHMARK_RESULTS_DIR)/baseline.json not found. Sym-link $(BENCHMARK_RESULTS_DIR)/baseline.json to a baseline-<state>-median.json first."; \
 		exit 1; \
 	fi
 	set -e ;\
-	maturin develop --release ;\
-	pytest tests/benchmark --benchmark-only \
-		--benchmark-compare=$(BENCHMARK_RESULTS_DIR)/baseline.json -v \
-		--benchmark-compare-fail=median:5% \
-		--benchmark-compare-fail=mean:15%
+	bash tests/benchmark/run_current.sh ;\
+	python3 tests/benchmark/aggregate.py --compare-current $(BENCHMARK_RESULTS_DIR)/current
 
 .PHONY: benchmark-history
 benchmark-history:

--- a/docs/tasks/69-median-of-n-gate.md
+++ b/docs/tasks/69-median-of-n-gate.md
@@ -1,0 +1,42 @@
+# Task 69 - Benchmark process improvements: median-of-N gate for `make benchmark-compare`
+
+GitHub issue: https://github.com/k9securityio/cedar-py/issues/69
+
+## Objective
+
+Implement **goal 3** of #69 — the only remaining goal. Goals 1 (release-mode `make benchmark*` targets) and 2 (release-mode median baseline) landed in PR #72; the historical-record bonus landed in PR #71 and was extended in PR #73.
+
+Replace the current single-current-run-vs-baseline-median gate with an **N=5 release-mode multi-run gate** that compares the **median Δ across N current runs at HEAD** against `tests/benchmark/results/baseline.json`. This removes the false-regression risk from tail-variance on any single run — the same root cause that made the #68 bisect unreadable until we built the N=5 aggregation in the first place.
+
+Reuse `tests/benchmark/aggregate.py`'s per-benchmark stats logic. The new pieces are a HEAD-only runner (no git-checkout dance like `capture_history.sh` does) and a comparator that computes median across N current runs and gates on median Δ.
+
+## High-level implementation steps
+
+1. Add a HEAD-only N-run runner under `tests/benchmark/` that does `maturin develop --release` once, then runs `pytest tests/benchmark` N times and writes per-run JSONs to a temp / results-scoped location.
+2. Extend `tests/benchmark/aggregate.py` (or add a sibling comparator) to load the N current-run JSONs, compute per-benchmark median, and compare against `baseline.json`'s per-stats-field median. Exit non-zero if any benchmark's median Δ exceeds the threshold.
+3. Rewire `make benchmark-compare` to invoke the runner + comparator instead of the current single-pytest-run `--benchmark-compare-fail` path.
+4. Honor `BENCHMARK_RUNS=N` override (default N=5).
+5. Print a concise summary table on both pass and fail (per-benchmark median Δ vs baseline), so a passing run still surfaces drift.
+6. Update `tests/benchmark/README.md` to document the new flow, the default N, and the override.
+
+## Questions
+
+1. **Threshold.** Current gate uses `pytest-benchmark`'s `--benchmark-compare-fail=median:5%,mean:15%`. Goal 3 explicitly says "apply thresholds to the **median** of the N runs, not a single-run mean." Drop the `mean` threshold entirely (per #69's out-of-scope note that the mean check is noisy by design and "should probably be dropped once goal 3 lands")? Or keep `mean` as an informational column but only fail on `median`?
+
+2. **Where the per-run JSONs live.** Two options:
+   - **Ephemeral**: write to a `tmp/` / `.benchmarks-current/` dir under `tests/benchmark/results/`, gitignored, cleaned up between runs. Keeps the committed results tree small.
+   - **Persistent**: write to `tests/benchmark/results/Darwin-…/` like the existing pytest-benchmark autosave path, leaving them for post-hoc investigation. Matches what's already happening (the five `0033_…0037_v4_8_2-runN.json` files in `git status` look like leftovers from a manual N=5 run).
+
+   Tilt: ephemeral, since `make benchmark-history` already owns the "captured for the record" use case. The pytest-benchmark autosaves are useful for ad-hoc work but shouldn't be the gate's storage.
+
+3. **Run-count default.** #69 specifies N=5. The PR #71 N=7 backfill found medians shifted by <1.3 pp at N=7 vs N=5, so N=5 is the right default. Confirm `BENCHMARK_RUNS` env override is the right knob (vs. a Makefile variable or CLI flag on the runner).
+
+4. **Reuse vs. fork of `aggregate.py`.** `aggregate.py` currently consumes the `states-manifest.json` produced by `capture_history.sh` (multiple states × multiple runs per state). The HEAD-only gate is a degenerate case (one "state" = HEAD, N runs). Add a `--current-runs <glob>` mode to `aggregate.py` that skips the states-manifest plumbing, or fork a smaller `compare_current.py`? Tilt: extend `aggregate.py` so the stats logic stays in one place.
+
+5. **CI exposure.** PR #72's progress comment on #69 flagged that `make benchmark-compare` is expected to fail on `test_complex_policy` at the time it was written — but PR #75 (Path B for #74) has since landed, which should have restored v4.8.0 perf on the default path. Worth re-running `make benchmark-compare` at current `main` (pre-this-work) to confirm the gate currently passes, so any failures introduced by the new N=5 logic are clearly attributable. Also: is `make benchmark-compare` actually invoked from any GitHub Actions workflow today, or is it maintainer-local only? If it runs in CI, the N=5 cost (5× `pytest tests/benchmark` ≈ several minutes per CI run) needs sign-off.
+
+6. **Stale autosave files.** The five `0033_…0037_v4_8_2-run*.json` files showing in `git status` look like artifacts from a prior manual N=5 attempt. Delete as part of this task, or leave for separate housekeeping?
+
+## Detailed implementation steps
+
+TODO: fill in after the questions above are resolved.

--- a/docs/tasks/69-median-of-n-gate.md
+++ b/docs/tasks/69-median-of-n-gate.md
@@ -23,19 +23,37 @@ Reuse `tests/benchmark/aggregate.py`'s per-benchmark stats logic. The new pieces
 
 1. **Threshold.** Current gate uses `pytest-benchmark`'s `--benchmark-compare-fail=median:5%,mean:15%`. Goal 3 explicitly says "apply thresholds to the **median** of the N runs, not a single-run mean." Drop the `mean` threshold entirely (per #69's out-of-scope note that the mean check is noisy by design and "should probably be dropped once goal 3 lands")? Or keep `mean` as an informational column but only fail on `median`?
 
+Decision: Drop the `mean` threshold evaluation.
+
 2. **Where the per-run JSONs live.** Two options:
    - **Ephemeral**: write to a `tmp/` / `.benchmarks-current/` dir under `tests/benchmark/results/`, gitignored, cleaned up between runs. Keeps the committed results tree small.
    - **Persistent**: write to `tests/benchmark/results/Darwin-…/` like the existing pytest-benchmark autosave path, leaving them for post-hoc investigation. Matches what's already happening (the five `0033_…0037_v4_8_2-runN.json` files in `git status` look like leftovers from a manual N=5 run).
 
    Tilt: ephemeral, since `make benchmark-history` already owns the "captured for the record" use case. The pytest-benchmark autosaves are useful for ad-hoc work but shouldn't be the gate's storage.
 
+Decision: Use the `ephemeral` approach. `make benchmark-history` will capture results "for the record".
+
 3. **Run-count default.** #69 specifies N=5. The PR #71 N=7 backfill found medians shifted by <1.3 pp at N=7 vs N=5, so N=5 is the right default. Confirm `BENCHMARK_RUNS` env override is the right knob (vs. a Makefile variable or CLI flag on the runner).
+
+Decision: use N=5 runs.
 
 4. **Reuse vs. fork of `aggregate.py`.** `aggregate.py` currently consumes the `states-manifest.json` produced by `capture_history.sh` (multiple states × multiple runs per state). The HEAD-only gate is a degenerate case (one "state" = HEAD, N runs). Add a `--current-runs <glob>` mode to `aggregate.py` that skips the states-manifest plumbing, or fork a smaller `compare_current.py`? Tilt: extend `aggregate.py` so the stats logic stays in one place.
 
+Decision: Extend `aggregate.py` so the stats logic stays in one place. 
+
 5. **CI exposure.** PR #72's progress comment on #69 flagged that `make benchmark-compare` is expected to fail on `test_complex_policy` at the time it was written — but PR #75 (Path B for #74) has since landed, which should have restored v4.8.0 perf on the default path. Worth re-running `make benchmark-compare` at current `main` (pre-this-work) to confirm the gate currently passes, so any failures introduced by the new N=5 logic are clearly attributable. Also: is `make benchmark-compare` actually invoked from any GitHub Actions workflow today, or is it maintainer-local only? If it runs in CI, the N=5 cost (5× `pytest tests/benchmark` ≈ several minutes per CI run) needs sign-off.
 
+v4.8.0 perf was restored on the default path (`main`).
+
+GitHub Actions do _not_ run benchmarks because the execution environment is too noisy / inconsistent.
+
+`make benchmark-compare` is only run by maintainers locally on their hardware prior to release. 
+
+Decision: You do not need to execute any 'official' runs to update benchmark history. But we will run `make benchmark-compare` on `main` to confirm the gate works and is (still) passing.
+
 6. **Stale autosave files.** The five `0033_…0037_v4_8_2-run*.json` files showing in `git status` look like artifacts from a prior manual N=5 attempt. Delete as part of this task, or leave for separate housekeeping?
+
+Decision: Delete them.
 
 ## Detailed implementation steps
 

--- a/docs/tasks/69-median-of-n-gate.md
+++ b/docs/tasks/69-median-of-n-gate.md
@@ -57,4 +57,104 @@ Decision: Delete them.
 
 ## Detailed implementation steps
 
-TODO: fill in after the questions above are resolved.
+File:line references are against `main` at the tip of branch `feat/issue-69-median-of-n-gate`.
+
+### Preflight
+
+1. **Confirm the current gate passes on `main`.** From a clean `venv-dev`, run `make benchmark-compare` on `main` (single-pytest-run vs `baseline.json`). Expectation per the #74/Path B resolution: passes. Record the per-benchmark median Δ output; it's the reference for sanity-checking the new N=5 gate's output in step 13.
+
+2. **Delete the stale autosave files.** `git rm` (or plain `rm` — they're untracked per `git status`) the five `tests/benchmark/results/Darwin-CPython-3.11-64bit/0033_…0037_v4_8_2-run*.json` files. They're leftovers from a manual N=5 attempt and are not part of the committed historical record (which uses the `v4_8_2:v4.8.2:v4.8.2` state in `capture_history.sh` and its own captured runs).
+
+### Runner — `tests/benchmark/run_current.sh` (new)
+
+3. **Add a HEAD-only N-run runner.** New file `tests/benchmark/run_current.sh`. Modeled on the inner loop of `capture_history.sh:87–108` but without the `git checkout` dance, the states-manifest plumbing, or the `restore_branch` trap. Responsibilities:
+   - Verify `venv-dev/` exists; `source venv-dev/bin/activate`.
+   - **Do not** require a clean working tree (the historical-record runner does; the gate runs on whatever HEAD has).
+   - Read `RUNS="${BENCHMARK_RUNS:-5}"`.
+   - Compute an ephemeral output dir under the project: `OUT_DIR="$REPO_ROOT/tests/benchmark/results/current"`. Wipe it at the start of each invocation (`rm -rf "$OUT_DIR" && mkdir -p "$OUT_DIR"`) so re-runs don't accidentally aggregate across stale files.
+   - `maturin develop --release` once (release-mode is the contract — `benchmark-compare` is release-mode-only after PR #72).
+   - Loop `n in 1..RUNS`, invoking `pytest tests/benchmark --benchmark-only --benchmark-json="$OUT_DIR/run$n.json" -q`. Use `--benchmark-json` (single explicit path) rather than `--benchmark-save` + `--benchmark-storage` so the runner owns the filenames directly and doesn't write into `Darwin-CPython-3.11-64bit/` (which is the historical record's home).
+   - On any pytest non-zero exit, exit non-zero immediately (set `-e` is enough).
+   - Print one tail-3 summary per run, matching `capture_history.sh`'s ergonomics.
+   - `chmod +x`.
+
+4. **Gitignore the ephemeral output dir.** Append `tests/benchmark/results/current/` to `.gitignore` (alongside the existing `tests/benchmark/results/out` entry on line 80). This keeps `git status` clean after `make benchmark-compare`.
+
+### Comparator — extend `tests/benchmark/aggregate.py`
+
+5. **Add a `--compare-current <dir>` mode.** New CLI flag on `aggregate.py:408–414`, mutually exclusive with `--phase` and `--build-baseline-from`. Argument is the runner's output dir (defaulting to `tests/benchmark/results/current/`). Calls a new `compare_current_to_baseline(current_dir, baseline_path, threshold_pct)` function and exits with that function's return code.
+
+6. **Implement `compare_current_to_baseline`.** New top-level function in `aggregate.py`. Steps:
+   - Load every `run*.json` under `current_dir`. If fewer than 1 file is present, exit non-zero with a clear error pointing the user at `run_current.sh`. (No lower bound > 1 — let the user run with `BENCHMARK_RUNS=1` if they want a fast-feedback debug loop; the gate just becomes single-run-vs-median in that case.)
+   - Build `current_means_us: dict[name -> list[float]]` by reading `b["stats"]["mean"]` per benchmark across runs (same convention as `per_benchmark_stats` at `aggregate.py:166–188` — convert to μs by `* 1_000_000`).
+   - Compute `current_median_us = statistics.median(means_us)` per benchmark.
+   - Load `tests/benchmark/results/baseline.json` and extract `baseline_median_us = b["stats"]["median"] * 1_000_000` per benchmark. Use the `"median"` stats field (the synthesized baseline's per-stats-field median across the v4.8.0 historical runs — see `build_baseline_from_state` at `aggregate.py:339–405`). Fall back gracefully (warn + skip) if a benchmark in `current_dir` isn't in the baseline or vice versa.
+   - Per benchmark, compute `delta_pct = (current_median_us - baseline_median_us) / baseline_median_us * 100`.
+   - Apply the threshold: **fail any benchmark where `delta_pct > THRESHOLD_PCT`** (default 5.0, matching the existing `--benchmark-compare-fail=median:5%`). Faster-than-baseline (negative Δ) never fails. Allow override via `--threshold-pct` CLI arg, but don't expose it through the Makefile in this PR (out of scope per #69's "regression-check threshold tuning is out of scope").
+   - Print a concise summary table to stdout in **all** cases (pass and fail):
+     ```
+     Benchmark                                          Baseline (μs)   Median (μs)   Δ median   Status
+     test_complex_policy                                273.3           272.4         -0.3%      PASS
+     test_medium_policy                                 ...
+     ```
+     One row per benchmark, sorted alphabetically. Use `fmt_us` / `fmt_pct` helpers (`aggregate.py:244–255`) for consistency with `HISTORY.md` formatting. Mark failing rows with `FAIL` so the maintainer can scan output quickly.
+   - Print a footer line indicating N (the run count) and the threshold used.
+   - Return non-zero if any benchmark FAIL'd; zero otherwise.
+
+7. **No `mean` threshold evaluation.** Per the resolved question, the comparator gates only on **median Δ**. Don't compute or print a `mean Δ` column — the goal is to remove the noisy mean check entirely, not preserve it as visual noise.
+
+8. **Don't fork — extend.** Per the resolved question, all new logic lives in `aggregate.py`. The existing functions (`per_benchmark_stats`, `build_baseline_from_state`, `phase_a`, `phase_b`) stay untouched.
+
+### Makefile — `make benchmark-compare`
+
+9. **Rewire the target.** Replace `Makefile:68–84`. New shape:
+   ```make
+   .PHONY: benchmark-compare
+   benchmark-compare:
+   	@echo Running benchmarks and comparing N runs against baseline
+   	@if [ ! -f $(BENCHMARK_RESULTS_DIR)/baseline.json ]; then \
+   		echo "Error: $(BENCHMARK_RESULTS_DIR)/baseline.json not found. Sym-link it to a baseline-<state>-median.json first."; \
+   		exit 1; \
+   	fi
+   	set -e ;\
+   	bash tests/benchmark/run_current.sh ;\
+   	python3 tests/benchmark/aggregate.py --compare-current $(BENCHMARK_RESULTS_DIR)/current
+   ```
+   - `BENCHMARK_RUNS=N make benchmark-compare` works transparently via the env-var passthrough in `run_current.sh`.
+   - Drop the comment block at `Makefile:70–72` (stddev/max noise note) — irrelevant under the new gate.
+   - Keep `maturin develop --release` inside `run_current.sh` so the build step stays adjacent to the runs (and is shared with any future `run_current.sh` invocations from outside `make`).
+
+10. **`make benchmark` and `benchmark-save` are unchanged.** Those are exploration targets; they stay single-run.
+
+### Docs
+
+11. **Update `tests/benchmark/README.md`.** Two updates to the "Single-run benchmarks" framing:
+    - Rename that workflow heading to acknowledge the gate is now multi-run (`benchmark-compare` is no longer single-run).
+    - Add a short subsection describing the new gate: N=5 release-mode runs at HEAD, median-Δ vs `baseline.json`, threshold 5%, override via `BENCHMARK_RUNS=N`. Point to `run_current.sh` and the `--compare-current` flag for ad-hoc invocation.
+
+12. **Update `CLAUDE.md`'s "Local dev workflow" benchmarks bullet.** Currently describes `make benchmark-compare` as a "single-run regression check." Reword to "N=5 release-mode runs at HEAD with median-Δ gating against `baseline.json`; override the run count via `BENCHMARK_RUNS=N`."
+
+### Validation
+
+13. **Smoke-test the new gate on `main`.** From a clean working tree at the tip of `feat/issue-69-median-of-n-gate`:
+    - `BENCHMARK_RUNS=2 make benchmark-compare` first — confirms the wiring end-to-end in ~2 min before paying the full N=5 cost.
+    - `make benchmark-compare` (default N=5). Expectation: PASS on all benchmarks, per the Path B (PR #75) restoration of v4.8.0 perf on the default code path. Compare per-benchmark median Δ against step 1's output as a sanity check — they should be within run-to-run noise.
+    - If any benchmark FAILs, investigate before merging: either Path B's perf hasn't fully held since PR #75 (real signal, file a follow-up), or the threshold is too tight for this hardware (unlikely — the 5% median threshold is what the existing gate already used).
+
+14. **Negative test the gate.** Manually plant a known-bad current run JSON in `tests/benchmark/results/current/` (e.g., by hand-editing one of the N=5 outputs to inflate `test_complex_policy`'s `stats.mean` by 20%) and re-run only the comparator (`python3 tests/benchmark/aggregate.py --compare-current tests/benchmark/results/current`). Confirm the gate exits non-zero and the row is marked FAIL. Discard the planted file.
+
+15. **Unit-test the comparator.** Add `tests/unit/test_aggregate_compare.py` (or extend an existing aggregate test if one exists — there isn't one as of this branch). Cover:
+    - Median Δ within threshold → returns 0, prints PASS.
+    - Median Δ above threshold → returns non-zero, prints FAIL for the offending benchmark.
+    - Faster-than-baseline (negative Δ) → never FAILs, prints negative Δ.
+    - Benchmark present in current but absent in baseline → warn + skip, don't crash.
+    - N=1 input → still produces a comparison (median of one sample = that sample).
+    Use small fabricated `run*.json` and `baseline.json` fixtures rather than real benchmark output.
+
+### Close-out
+
+16. **CHANGELOG.** Add an entry under `[Unreleased]` describing the gate change: "`make benchmark-compare` now runs N=5 release-mode benchmarks at HEAD and gates on median Δ vs `baseline.json` (was: single pytest-benchmark run with `--benchmark-compare-fail=median:5%,mean:15%`). The `mean` threshold has been dropped; only median Δ is gated. Override the run count with `BENCHMARK_RUNS=N`."
+
+17. **PR description.** Reference #69 and call out: (a) Goal 3 is now done, closing the issue when this PR merges; (b) the `mean` threshold drop, per #69's out-of-scope note; (c) the ephemeral results directory and the `.gitignore` addition; (d) the deleted stale autosave files. `Resolves #69`.
+
+18. **After merge.** Confirm #69 auto-closes. Optional follow-up housekeeping (out of scope here, captured for the record): delete the closed `feat/issue-69-state-pr70` and `fix/optional-resolve-policy-ids` branches on origin, per the side note in `74-id-annotation-support.md`.

--- a/docs/tasks/69-median-of-n-gate.md
+++ b/docs/tasks/69-median-of-n-gate.md
@@ -61,13 +61,13 @@ File:line references are against `main` at the tip of branch `feat/issue-69-medi
 
 ### Preflight
 
-1. **Confirm the current gate passes on `main`.** From a clean `venv-dev`, run `make benchmark-compare` on `main` (single-pytest-run vs `baseline.json`). Expectation per the #74/Path B resolution: passes. Record the per-benchmark median Δ output; it's the reference for sanity-checking the new N=5 gate's output in step 13.
+1. ❌ **Confirm the current gate passes on `main`.** Deferred to the user per task decision (#5): the maintainer runs `make benchmark-compare` locally to validate. From a clean `venv-dev`, run `make benchmark-compare` on `main` (single-pytest-run vs `baseline.json`). Expectation per the #74/Path B resolution: passes. Record the per-benchmark median Δ output; it's the reference for sanity-checking the new N=5 gate's output in step 13.
 
-2. **Delete the stale autosave files.** `git rm` (or plain `rm` — they're untracked per `git status`) the five `tests/benchmark/results/Darwin-CPython-3.11-64bit/0033_…0037_v4_8_2-run*.json` files. They're leftovers from a manual N=5 attempt and are not part of the committed historical record (which uses the `v4_8_2:v4.8.2:v4.8.2` state in `capture_history.sh` and its own captured runs).
+2. ✅ **Delete the stale autosave files.** `git rm` (or plain `rm` — they're untracked per `git status`) the five `tests/benchmark/results/Darwin-CPython-3.11-64bit/0033_…0037_v4_8_2-run*.json` files. They're leftovers from a manual N=5 attempt and are not part of the committed historical record (which uses the `v4_8_2:v4.8.2:v4.8.2` state in `capture_history.sh` and its own captured runs).
 
 ### Runner — `tests/benchmark/run_current.sh` (new)
 
-3. **Add a HEAD-only N-run runner.** New file `tests/benchmark/run_current.sh`. Modeled on the inner loop of `capture_history.sh:87–108` but without the `git checkout` dance, the states-manifest plumbing, or the `restore_branch` trap. Responsibilities:
+3. ✅ **Add a HEAD-only N-run runner.** New file `tests/benchmark/run_current.sh`. Modeled on the inner loop of `capture_history.sh:87–108` but without the `git checkout` dance, the states-manifest plumbing, or the `restore_branch` trap. Responsibilities:
    - Verify `venv-dev/` exists; `source venv-dev/bin/activate`.
    - **Do not** require a clean working tree (the historical-record runner does; the gate runs on whatever HEAD has).
    - Read `RUNS="${BENCHMARK_RUNS:-5}"`.
@@ -78,13 +78,13 @@ File:line references are against `main` at the tip of branch `feat/issue-69-medi
    - Print one tail-3 summary per run, matching `capture_history.sh`'s ergonomics.
    - `chmod +x`.
 
-4. **Gitignore the ephemeral output dir.** Append `tests/benchmark/results/current/` to `.gitignore` (alongside the existing `tests/benchmark/results/out` entry on line 80). This keeps `git status` clean after `make benchmark-compare`.
+4. ✅ **Gitignore the ephemeral output dir.** Append `tests/benchmark/results/current/` to `.gitignore` (alongside the existing `tests/benchmark/results/out` entry on line 80). This keeps `git status` clean after `make benchmark-compare`.
 
 ### Comparator — extend `tests/benchmark/aggregate.py`
 
-5. **Add a `--compare-current <dir>` mode.** New CLI flag on `aggregate.py:408–414`, mutually exclusive with `--phase` and `--build-baseline-from`. Argument is the runner's output dir (defaulting to `tests/benchmark/results/current/`). Calls a new `compare_current_to_baseline(current_dir, baseline_path, threshold_pct)` function and exits with that function's return code.
+5. ✅ **Add a `--compare-current <dir>` mode.** New CLI flag on `aggregate.py:408–414`, mutually exclusive with `--phase` and `--build-baseline-from`. Argument is the runner's output dir (defaulting to `tests/benchmark/results/current/`). Calls a new `compare_current_to_baseline(current_dir, baseline_path, threshold_pct)` function and exits with that function's return code.
 
-6. **Implement `compare_current_to_baseline`.** New top-level function in `aggregate.py`. Steps:
+6. ✅ **Implement `compare_current_to_baseline`.** New top-level function in `aggregate.py`. Steps:
    - Load every `run*.json` under `current_dir`. If fewer than 1 file is present, exit non-zero with a clear error pointing the user at `run_current.sh`. (No lower bound > 1 — let the user run with `BENCHMARK_RUNS=1` if they want a fast-feedback debug loop; the gate just becomes single-run-vs-median in that case.)
    - Build `current_means_us: dict[name -> list[float]]` by reading `b["stats"]["mean"]` per benchmark across runs (same convention as `per_benchmark_stats` at `aggregate.py:166–188` — convert to μs by `* 1_000_000`).
    - Compute `current_median_us = statistics.median(means_us)` per benchmark.
@@ -101,13 +101,13 @@ File:line references are against `main` at the tip of branch `feat/issue-69-medi
    - Print a footer line indicating N (the run count) and the threshold used.
    - Return non-zero if any benchmark FAIL'd; zero otherwise.
 
-7. **No `mean` threshold evaluation.** Per the resolved question, the comparator gates only on **median Δ**. Don't compute or print a `mean Δ` column — the goal is to remove the noisy mean check entirely, not preserve it as visual noise.
+7. ✅ **No `mean` threshold evaluation.** Per the resolved question, the comparator gates only on **median Δ**. Don't compute or print a `mean Δ` column — the goal is to remove the noisy mean check entirely, not preserve it as visual noise.
 
-8. **Don't fork — extend.** Per the resolved question, all new logic lives in `aggregate.py`. The existing functions (`per_benchmark_stats`, `build_baseline_from_state`, `phase_a`, `phase_b`) stay untouched.
+8. ✅ **Don't fork — extend.** Per the resolved question, all new logic lives in `aggregate.py`. The existing functions (`per_benchmark_stats`, `build_baseline_from_state`, `phase_a`, `phase_b`) stay untouched.
 
 ### Makefile — `make benchmark-compare`
 
-9. **Rewire the target.** Replace `Makefile:68–84`. New shape:
+9. ✅ **Rewire the target.** Replace `Makefile:68–84`. New shape:
    ```make
    .PHONY: benchmark-compare
    benchmark-compare:
@@ -124,26 +124,26 @@ File:line references are against `main` at the tip of branch `feat/issue-69-medi
    - Drop the comment block at `Makefile:70–72` (stddev/max noise note) — irrelevant under the new gate.
    - Keep `maturin develop --release` inside `run_current.sh` so the build step stays adjacent to the runs (and is shared with any future `run_current.sh` invocations from outside `make`).
 
-10. **`make benchmark` and `benchmark-save` are unchanged.** Those are exploration targets; they stay single-run.
+10. ✅ **`make benchmark` and `benchmark-save` are unchanged.** Those are exploration targets; they stay single-run.
 
 ### Docs
 
-11. **Update `tests/benchmark/README.md`.** Two updates to the "Single-run benchmarks" framing:
+11. ✅ **Update `tests/benchmark/README.md`.** Two updates to the "Single-run benchmarks" framing:
     - Rename that workflow heading to acknowledge the gate is now multi-run (`benchmark-compare` is no longer single-run).
     - Add a short subsection describing the new gate: N=5 release-mode runs at HEAD, median-Δ vs `baseline.json`, threshold 5%, override via `BENCHMARK_RUNS=N`. Point to `run_current.sh` and the `--compare-current` flag for ad-hoc invocation.
 
-12. **Update `CLAUDE.md`'s "Local dev workflow" benchmarks bullet.** Currently describes `make benchmark-compare` as a "single-run regression check." Reword to "N=5 release-mode runs at HEAD with median-Δ gating against `baseline.json`; override the run count via `BENCHMARK_RUNS=N`."
+12. ✅ **Update `CLAUDE.md`'s "Local dev workflow" benchmarks bullet.** Currently describes `make benchmark-compare` as a "single-run regression check." Reword to "N=5 release-mode runs at HEAD with median-Δ gating against `baseline.json`; override the run count via `BENCHMARK_RUNS=N`."
 
 ### Validation
 
-13. **Smoke-test the new gate on `main`.** From a clean working tree at the tip of `feat/issue-69-median-of-n-gate`:
+13. ✅ **Smoke-test the new gate.** Default N=5 `make benchmark-compare` ran clean on the branch (bc63f01): all 26 benchmarks PASS, every median Δ within ±2.4% of baseline. The N=1 vs N=5 contrast is the punchline of goal 3: `test_simple_policy_allow` was +83.8% at N=1 (single-run noise on a 144μs benchmark) and +1.2% at N=5. Median-of-N is doing exactly what the issue motivated. From a clean working tree at the tip of `feat/issue-69-median-of-n-gate`:
     - `BENCHMARK_RUNS=2 make benchmark-compare` first — confirms the wiring end-to-end in ~2 min before paying the full N=5 cost.
     - `make benchmark-compare` (default N=5). Expectation: PASS on all benchmarks, per the Path B (PR #75) restoration of v4.8.0 perf on the default code path. Compare per-benchmark median Δ against step 1's output as a sanity check — they should be within run-to-run noise.
     - If any benchmark FAILs, investigate before merging: either Path B's perf hasn't fully held since PR #75 (real signal, file a follow-up), or the threshold is too tight for this hardware (unlikely — the 5% median threshold is what the existing gate already used).
 
-14. **Negative test the gate.** Manually plant a known-bad current run JSON in `tests/benchmark/results/current/` (e.g., by hand-editing one of the N=5 outputs to inflate `test_complex_policy`'s `stats.mean` by 20%) and re-run only the comparator (`python3 tests/benchmark/aggregate.py --compare-current tests/benchmark/results/current`). Confirm the gate exits non-zero and the row is marked FAIL. Discard the planted file.
+14. ❌ **Negative test the gate (manual hand-edit).** Superseded by step 15's unit tests, which cover the FAIL path with fabricated fixtures more reliably than a hand-edit-and-discard procedure. Manually plant a known-bad current run JSON in `tests/benchmark/results/current/` (e.g., by hand-editing one of the N=5 outputs to inflate `test_complex_policy`'s `stats.mean` by 20%) and re-run only the comparator (`python3 tests/benchmark/aggregate.py --compare-current tests/benchmark/results/current`). Confirm the gate exits non-zero and the row is marked FAIL. Discard the planted file.
 
-15. **Unit-test the comparator.** Add `tests/unit/test_aggregate_compare.py` (or extend an existing aggregate test if one exists — there isn't one as of this branch). Cover:
+15. ✅ **Unit-test the comparator.** Landed as `tests/unit/test_benchmark_compare.py` — 8 tests, all passing. Covers: within-threshold PASS, over-threshold FAIL, faster-than-baseline never-fails, benchmark in current but not baseline (warn+skip), benchmark in baseline but not current (warn+skip), N=1 input, no run files → SystemExit, missing baseline → SystemExit. Add `tests/unit/test_aggregate_compare.py` (or extend an existing aggregate test if one exists — there isn't one as of this branch). Cover:
     - Median Δ within threshold → returns 0, prints PASS.
     - Median Δ above threshold → returns non-zero, prints FAIL for the offending benchmark.
     - Faster-than-baseline (negative Δ) → never FAILs, prints negative Δ.
@@ -153,8 +153,8 @@ File:line references are against `main` at the tip of branch `feat/issue-69-medi
 
 ### Close-out
 
-16. **CHANGELOG.** Add an entry under `[Unreleased]` describing the gate change: "`make benchmark-compare` now runs N=5 release-mode benchmarks at HEAD and gates on median Δ vs `baseline.json` (was: single pytest-benchmark run with `--benchmark-compare-fail=median:5%,mean:15%`). The `mean` threshold has been dropped; only median Δ is gated. Override the run count with `BENCHMARK_RUNS=N`."
+16. ✅ **CHANGELOG.** Add an entry under `[Unreleased]` describing the gate change: "`make benchmark-compare` now runs N=5 release-mode benchmarks at HEAD and gates on median Δ vs `baseline.json` (was: single pytest-benchmark run with `--benchmark-compare-fail=median:5%,mean:15%`). The `mean` threshold has been dropped; only median Δ is gated. Override the run count with `BENCHMARK_RUNS=N`."
 
-17. **PR description.** Reference #69 and call out: (a) Goal 3 is now done, closing the issue when this PR merges; (b) the `mean` threshold drop, per #69's out-of-scope note; (c) the ephemeral results directory and the `.gitignore` addition; (d) the deleted stale autosave files. `Resolves #69`.
+17. 🚧 **PR description.** To be drafted when the user is ready to open the PR. Reference #69 and call out: (a) Goal 3 is now done, closing the issue when this PR merges; (b) the `mean` threshold drop, per #69's out-of-scope note; (c) the ephemeral results directory and the `.gitignore` addition; (d) the deleted stale autosave files. `Resolves #69`.
 
-18. **After merge.** Confirm #69 auto-closes. Optional follow-up housekeeping (out of scope here, captured for the record): delete the closed `feat/issue-69-state-pr70` and `fix/optional-resolve-policy-ids` branches on origin, per the side note in `74-id-annotation-support.md`.
+18. 🚧 **After merge.** Pending PR merge. Confirm #69 auto-closes. Optional follow-up housekeeping (out of scope here, captured for the record): delete the closed `feat/issue-69-state-pr70` and `fix/optional-resolve-policy-ids` branches on origin, per the side note in `74-id-annotation-support.md`.

--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -1,19 +1,38 @@
 # cedarpy benchmark suite
 
-`pytest-benchmark` suite for cedarpy. Two distinct workflows live here:
+`pytest-benchmark` suite for cedarpy. Three workflows live here:
 
-1. **Single-run benchmarks** — the `make benchmark*` targets (run / save / compare-against-baseline). See `Makefile`.
-2. **Historical record** — multi-run release-mode capture across a list of historical commits, aggregated into a committed perf history (this README is mostly about this).
+1. **Ad-hoc benchmarks** — `make benchmark` / `make benchmark-save` for single-run exploration. See `Makefile`.
+2. **Regression gate** — `make benchmark-compare` runs N=5 release-mode benchmarks at HEAD and gates on median Δ vs `results/baseline.json` (see "The regression gate" below).
+3. **Historical record** — multi-run release-mode capture across a list of historical commits, aggregated into a committed perf history (most of this README).
 
 ## Files
 
 - `test_benchmark_authorize.py` — the benchmarks themselves.
+- `run_current.sh` — runs N=5 release-mode benchmarks at HEAD; writes ephemeral per-run JSONs into `results/current/` (gitignored).
 - `capture_history.sh` — captures release-mode runs at each historical commit; writes native pytest-benchmark JSONs.
-- `aggregate.py` — reads native JSONs, writes per-commit summary JSONs and `HISTORY.md`.
+- `aggregate.py` — three modes:
+  - default (`--phase ab`): reads native JSONs, writes per-commit summary JSONs and `HISTORY.md`.
+  - `--build-baseline-from <state>`: synthesizes a median-of-N baseline JSON from a committed historical state.
+  - `--compare-current [DIR]`: compares per-benchmark median across N current runs against `baseline.json` and exits non-zero on regression.
 - `results/Darwin-CPython-3.11-64bit/` — native pytest-benchmark JSONs (one per pytest invocation, autoincremented).
+- `results/current/` — ephemeral per-run JSONs from `run_current.sh` (gitignored, wiped each invocation).
 - `results/history/<state>.json` — per-commit summary (median/max/min/stdev across N runs per benchmark).
 - `results/HISTORY.md` — rendered table view of `results/history/*.json`, one section per benchmark.
-- `results/baseline.json` — used by `make benchmark-compare` (single-run comparison gate).
+- `results/baseline.json` — symlink to the active baseline (typically `baseline-v4_8_0-median.json`); used by `make benchmark-compare`.
+
+## The regression gate
+
+```sh
+make benchmark-compare
+```
+
+Runs `bash run_current.sh` (one release-mode rebuild + N pytest invocations writing to `results/current/run<N>.json`), then `python tests/benchmark/aggregate.py --compare-current` (loads the N runs, computes per-benchmark median μs, compares against `baseline.json`'s `stats.median` per benchmark, and gates on **median Δ > 5%**). A summary table prints on both pass and fail, so drift is visible even when the gate passes.
+
+- **N defaults to 5.** Override per-invocation: `BENCHMARK_RUNS=2 make benchmark-compare` (fast smoke test) or `BENCHMARK_RUNS=10 make benchmark-compare` (tighter median).
+- **The gate is median-only.** The previous `mean:15%` threshold was dropped as noisy by design — a single tail outlier could trip a passing run. The N=5 median is the stable signal.
+- **Faster-than-baseline never fails.** Only positive Δ exceeding the threshold is a regression.
+- The runner does NOT require a clean working tree; the gate runs on whatever HEAD has. Build mode is always release (`maturin develop --release`).
 
 ## Capturing the historical record
 

--- a/tests/benchmark/aggregate.py
+++ b/tests/benchmark/aggregate.py
@@ -405,13 +405,130 @@ def build_baseline_from_state(save_prefix: str, output_path: Path | None = None)
     return output_path
 
 
+DEFAULT_CURRENT_DIR = RESULTS_DIR / "current"
+BASELINE_PATH = RESULTS_DIR / "baseline.json"
+DEFAULT_THRESHOLD_PCT = 5.0
+
+
+def _rel(path: Path) -> str:
+    """Path relative to REPO_ROOT if possible, else absolute. For display only."""
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def _load_current_runs(current_dir: Path) -> dict[str, list[float]]:
+    """Return per-benchmark list of per-run mean times (μs) from current_dir/run*.json."""
+    run_files = sorted(current_dir.glob("run*.json"))
+    if not run_files:
+        sys.exit(
+            f"error: no run*.json files in {_rel(current_dir)}. "
+            f"Run `bash tests/benchmark/run_current.sh` first."
+        )
+    means_by_name: dict[str, list[float]] = {}
+    for path in run_files:
+        data = json.loads(path.read_text())
+        for b in data["benchmarks"]:
+            means_by_name.setdefault(b["name"], []).append(b["stats"]["mean"] * 1_000_000)
+    return means_by_name
+
+
+def _load_baseline_medians(baseline_path: Path) -> dict[str, float]:
+    """Return per-benchmark baseline median time (μs) from baseline.json's stats.median field."""
+    if not baseline_path.exists():
+        sys.exit(
+            f"error: baseline not found at {_rel(baseline_path)}. "
+            f"Symlink baseline.json to a baseline-<state>-median.json first."
+        )
+    data = json.loads(baseline_path.read_text())
+    return {b["name"]: b["stats"]["median"] * 1_000_000 for b in data["benchmarks"]}
+
+
+def compare_current_to_baseline(
+    current_dir: Path = DEFAULT_CURRENT_DIR,
+    baseline_path: Path = BASELINE_PATH,
+    threshold_pct: float = DEFAULT_THRESHOLD_PCT,
+) -> int:
+    """Compare median across N current runs against baseline median per benchmark.
+
+    Gates on median Δ only (no mean threshold, per #69 goal 3). Faster-than-
+    baseline never fails. Prints a per-benchmark PASS/FAIL summary table for
+    both passing and failing outcomes. Returns 0 if all benchmarks pass, 1 if
+    any benchmark's median Δ exceeds threshold_pct.
+    """
+    current_means = _load_current_runs(current_dir)
+    baseline_medians = _load_baseline_medians(baseline_path)
+
+    n_runs = max((len(v) for v in current_means.values()), default=0)
+    all_names = sorted(set(current_means) | set(baseline_medians))
+
+    rows: list[tuple[str, float | None, float | None, float | None, str]] = []
+    any_fail = False
+    skipped_warnings: list[str] = []
+
+    for name in all_names:
+        means = current_means.get(name)
+        baseline_med = baseline_medians.get(name)
+        if means is None:
+            skipped_warnings.append(f"  {name}: present in baseline but no current runs — skipped")
+            continue
+        if baseline_med is None or baseline_med <= 0:
+            skipped_warnings.append(f"  {name}: present in current runs but no baseline — skipped")
+            continue
+        cur_med = statistics.median(means)
+        delta_pct = (cur_med - baseline_med) / baseline_med * 100
+        status = "FAIL" if delta_pct > threshold_pct else "PASS"
+        if status == "FAIL":
+            any_fail = True
+        rows.append((name, baseline_med, cur_med, delta_pct, status))
+
+    name_w = max((len(r[0]) for r in rows), default=10)
+    name_w = max(name_w, len("Benchmark"))
+    print()
+    print(f"{'Benchmark':<{name_w}}  {'Baseline (μs)':>13}  {'Median (μs)':>11}  {'Δ median':>9}  Status")
+    print(f"{'-' * name_w}  {'-' * 13}  {'-' * 11}  {'-' * 9}  ------")
+    for name, base, cur, delta, status in rows:
+        print(
+            f"{name:<{name_w}}  {fmt_us(base):>13}  {fmt_us(cur):>11}  "
+            f"{fmt_pct(cur, base):>9}  {status}"
+        )
+
+    if skipped_warnings:
+        print("\nwarnings:")
+        for w in skipped_warnings:
+            print(w)
+
+    print(
+        f"\nN={n_runs} current runs vs {_rel(baseline_path)}; "
+        f"threshold: median Δ > {threshold_pct:g}% fails"
+    )
+    if any_fail:
+        print("RESULT: FAIL — one or more benchmarks regressed beyond threshold")
+        return 1
+    print("RESULT: PASS")
+    return 0
+
+
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--phase", choices=["a", "b", "ab"], default="ab",
                    help="run phase A (raw → per-commit JSON), phase B (per-commit JSON → markdown), or both (default)")
     p.add_argument("--build-baseline-from", metavar="SAVE_PREFIX",
                    help="alternative mode: synthesize baseline.json from the median of <SAVE_PREFIX>'s runs (skips phases A/B)")
+    p.add_argument("--compare-current", nargs="?", const=str(DEFAULT_CURRENT_DIR),
+                   metavar="DIR",
+                   help=f"alternative mode: compare run*.json in DIR (default {DEFAULT_CURRENT_DIR.relative_to(REPO_ROOT)}) "
+                        f"against baseline.json on median Δ; exits non-zero on regression")
+    p.add_argument("--threshold-pct", type=float, default=DEFAULT_THRESHOLD_PCT,
+                   help=f"median Δ regression threshold percent (default {DEFAULT_THRESHOLD_PCT}); used with --compare-current")
     args = p.parse_args()
+
+    if args.compare_current:
+        return compare_current_to_baseline(
+            current_dir=Path(args.compare_current),
+            threshold_pct=args.threshold_pct,
+        )
 
     if args.build_baseline_from:
         build_baseline_from_state(args.build_baseline_from)

--- a/tests/benchmark/run_current.sh
+++ b/tests/benchmark/run_current.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Capture N release-mode pytest-benchmark runs at HEAD for `make benchmark-compare`.
+#
+# Unlike capture_history.sh, this script does NOT switch branches, NOT require
+# a clean working tree, and NOT write into the committed historical record
+# (tests/benchmark/results/Darwin-CPython-3.11-64bit/). It writes ephemeral
+# per-run JSONs into tests/benchmark/results/current/ (gitignored), which the
+# comparator (aggregate.py --compare-current) then aggregates and gates on
+# median Δ vs baseline.json.
+#
+# Run count: BENCHMARK_RUNS (default 5).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+if [ ! -d "venv-dev" ]; then
+  echo "ERROR: venv-dev not found. Run 'make venv-dev' first." >&2
+  exit 1
+fi
+# shellcheck disable=SC1091
+source venv-dev/bin/activate
+
+RUNS="${BENCHMARK_RUNS:-5}"
+OUT_DIR="$REPO_ROOT/tests/benchmark/results/current"
+
+echo "===== HEAD: $(git log --oneline -1) ====="
+echo "===== RUNS=$RUNS  OUT_DIR=${OUT_DIR#$REPO_ROOT/} ====="
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+
+echo "---- building (release) at $(date +%H:%M:%S) ----"
+maturin develop --release 2>&1 | tail -3
+
+for n in $(seq 1 "$RUNS"); do
+  out="$OUT_DIR/run$n.json"
+  echo "  [$(date +%H:%M:%S)] run $n -> ${out#$REPO_ROOT/}"
+  pytest tests/benchmark --benchmark-only \
+    --benchmark-json="$out" \
+    -q 2>&1 | tail -3
+done
+
+echo "===== DONE at $(date +%H:%M:%S) ====="

--- a/tests/unit/test_benchmark_compare.py
+++ b/tests/unit/test_benchmark_compare.py
@@ -1,0 +1,169 @@
+"""Unit tests for tests/benchmark/aggregate.py's --compare-current mode."""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AGGREGATE_PATH = REPO_ROOT / "tests" / "benchmark" / "aggregate.py"
+
+
+def _load_aggregate():
+    spec = importlib.util.spec_from_file_location("benchmark_aggregate", AGGREGATE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+aggregate = _load_aggregate()
+
+
+def _write_run(path: Path, means_by_name: dict[str, float]) -> None:
+    """Write a minimal pytest-benchmark-shaped JSON with given per-benchmark mean (seconds)."""
+    path.write_text(json.dumps({
+        "benchmarks": [
+            {"name": name, "stats": {"mean": mean}}
+            for name, mean in means_by_name.items()
+        ]
+    }))
+
+
+def _write_baseline(path: Path, medians_by_name: dict[str, float]) -> None:
+    """Write a minimal baseline JSON with per-benchmark stats.median (seconds)."""
+    path.write_text(json.dumps({
+        "benchmarks": [
+            {"name": name, "stats": {"median": median}}
+            for name, median in medians_by_name.items()
+        ]
+    }))
+
+
+def test_compare_passes_when_within_threshold(tmp_path, capsys):
+    current = tmp_path / "current"
+    current.mkdir()
+    # Baseline median 100μs (= 0.0001s). Current runs: 100, 101, 102 μs → median 101μs → +1% Δ.
+    _write_run(current / "run1.json", {"bench_a": 0.000100})
+    _write_run(current / "run2.json", {"bench_a": 0.000101})
+    _write_run(current / "run3.json", {"bench_a": 0.000102})
+
+    baseline = tmp_path / "baseline.json"
+    _write_baseline(baseline, {"bench_a": 0.000100})
+
+    rc = aggregate.compare_current_to_baseline(current, baseline, threshold_pct=5.0)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "PASS" in out
+    assert "FAIL" not in out
+    assert "RESULT: PASS" in out
+
+
+def test_compare_fails_when_median_exceeds_threshold(tmp_path, capsys):
+    current = tmp_path / "current"
+    current.mkdir()
+    # Baseline 100μs. Current medians: 120μs → +20% Δ → FAIL at 5% threshold.
+    _write_run(current / "run1.json", {"bench_a": 0.000118})
+    _write_run(current / "run2.json", {"bench_a": 0.000120})
+    _write_run(current / "run3.json", {"bench_a": 0.000122})
+
+    baseline = tmp_path / "baseline.json"
+    _write_baseline(baseline, {"bench_a": 0.000100})
+
+    rc = aggregate.compare_current_to_baseline(current, baseline, threshold_pct=5.0)
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "FAIL" in out
+    assert "RESULT: FAIL" in out
+
+
+def test_compare_passes_when_faster_than_baseline(tmp_path, capsys):
+    current = tmp_path / "current"
+    current.mkdir()
+    # Baseline 100μs. Current median 50μs → -50% Δ → must PASS (faster never fails).
+    _write_run(current / "run1.json", {"bench_a": 0.000050})
+    _write_run(current / "run2.json", {"bench_a": 0.000050})
+
+    baseline = tmp_path / "baseline.json"
+    _write_baseline(baseline, {"bench_a": 0.000100})
+
+    rc = aggregate.compare_current_to_baseline(current, baseline, threshold_pct=5.0)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "RESULT: PASS" in out
+    # Negative Δ should appear in output
+    assert "-50" in out
+
+
+def test_compare_skips_benchmark_missing_from_baseline(tmp_path, capsys):
+    current = tmp_path / "current"
+    current.mkdir()
+    _write_run(current / "run1.json", {"bench_a": 0.000100, "bench_new": 0.000100})
+
+    baseline = tmp_path / "baseline.json"
+    _write_baseline(baseline, {"bench_a": 0.000100})
+
+    rc = aggregate.compare_current_to_baseline(current, baseline, threshold_pct=5.0)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "bench_new" in out
+    assert "no baseline" in out
+
+
+def test_compare_skips_benchmark_missing_from_current(tmp_path, capsys):
+    current = tmp_path / "current"
+    current.mkdir()
+    _write_run(current / "run1.json", {"bench_a": 0.000100})
+
+    baseline = tmp_path / "baseline.json"
+    _write_baseline(baseline, {"bench_a": 0.000100, "bench_gone": 0.000200})
+
+    rc = aggregate.compare_current_to_baseline(current, baseline, threshold_pct=5.0)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "bench_gone" in out
+    assert "no current runs" in out
+
+
+def test_compare_works_with_single_run(tmp_path, capsys):
+    current = tmp_path / "current"
+    current.mkdir()
+    _write_run(current / "run1.json", {"bench_a": 0.000101})
+
+    baseline = tmp_path / "baseline.json"
+    _write_baseline(baseline, {"bench_a": 0.000100})
+
+    rc = aggregate.compare_current_to_baseline(current, baseline, threshold_pct=5.0)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "N=1" in out
+
+
+def test_compare_exits_when_no_run_files(tmp_path):
+    current = tmp_path / "current"
+    current.mkdir()
+
+    baseline = tmp_path / "baseline.json"
+    _write_baseline(baseline, {"bench_a": 0.000100})
+
+    try:
+        aggregate.compare_current_to_baseline(current, baseline)
+    except SystemExit as e:
+        assert e.code and "no run*.json" in str(e.code)
+    else:
+        raise AssertionError("expected SystemExit when no run files present")
+
+
+def test_compare_exits_when_baseline_missing(tmp_path):
+    current = tmp_path / "current"
+    current.mkdir()
+    _write_run(current / "run1.json", {"bench_a": 0.000100})
+
+    missing_baseline = tmp_path / "does_not_exist.json"
+
+    try:
+        aggregate.compare_current_to_baseline(current, missing_baseline)
+    except SystemExit as e:
+        assert e.code and "baseline not found" in str(e.code)
+    else:
+        raise AssertionError("expected SystemExit when baseline missing")


### PR DESCRIPTION
## Summary

- Replaces `make benchmark-compare`'s single pytest-benchmark run + `--benchmark-compare-fail=median:5%,mean:15%` with an **N=5 release-mode multi-run gate** that compares median Δ across runs against `tests/benchmark/results/baseline.json`. Closes #69 goal 3 (goals 1, 2 landed in #72; historical record in #71/#73).
- New `tests/benchmark/run_current.sh` runs N release-mode benchmarks at HEAD into an ephemeral, gitignored `results/current/`. New `aggregate.py --compare-current` loads them, computes per-benchmark median, gates on median Δ > 5%, and prints a PASS/FAIL table on every run.
- Mean threshold dropped — noisy by design per #69's out-of-scope note. Median-only gating.
- `BENCHMARK_RUNS=N` honored end-to-end (default 5).

## Verification

End-to-end smoke test on this branch:

| N | `test_simple_policy_allow` Δ | Result |
|---|---|---|
| 1 | +83.8% (single-run noise on 144μs benchmark) | FAIL |
| 5 | +1.2% | PASS |

At N=5 all 26 benchmarks pass within ±2.4% of baseline. The N=1 vs N=5 contrast is the punchline of goal 3.

8 unit tests added in `tests/unit/test_benchmark_compare.py` covering pass / fail / faster-than-baseline / benchmark-missing-from-baseline / benchmark-missing-from-current / N=1 / missing run files / missing baseline.

## Test plan

- [x] `pytest tests/unit/test_benchmark_compare.py` — 8/8 pass
- [x] `make benchmark-compare` (default N=5) — PASS on all 26 benchmarks
- [x] `BENCHMARK_RUNS=1 make benchmark-compare` — FAILs as expected (single-run noise on fast benchmarks)
- [ ] Reviewer: confirm `tests/benchmark/results/current/` stays out of `git status` after a run (gitignored)
- [ ] Reviewer: confirm the dropped `mean` threshold is the desired behavior — #69's out-of-scope note flagged it for removal once goal 3 lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)
