### PR TITLE
release: cedarpy 4.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [4.8.4] - 2026-05-29
+
 ### Added
 
-- Adds `is_authorized_partial(request, policies, entities, schema=None)` for Cedar's partial-evaluation authorizer. Request fields that are `None` or absent are treated as unknowns. The authorizer returns `Decision.Allow` or `Decision.Deny` when the unknowns can't change the outcome, and `Decision.NoDecision` plus residual policies (as Cedar JSON) otherwise; callers re-evaluate the residuals once the unknowns are bound. `PartialAuthzResult` uses the same `decision` / `correlation_id` / `diagnostics` / `metrics` structure as `AuthzResult`, with `may_be_determining`, `must_be_determining`, `nontrivial_residuals`, and `unknown_entities` added to diagnostics. Unlike `is_authorized`, an absent or `None` `context` is treated as unknown rather than empty. Pass `context={}` for an explicitly empty context. **Note: A partial-eval result is not a final authorization decision.** Re-run `is_authorized` once unknowns are bound; schema type-checking (including action-typed context shapes) is skipped while fields remain unknown. Enables the `partial-eval` Cargo feature on `cedar-policy` ([#28](https://github.com/k9securityio/cedar-py/issues/28)) — Thanks [@swenger](https://github.com/swenger)! 
+- Adds `is_authorized_partial(request, policies, entities, schema=None)` for Cedar's partial-evaluation authorizer. Request fields that are `None` or absent are treated as unknowns. The authorizer returns `Decision.Allow` or `Decision.Deny` when the unknowns can't change the outcome, and `Decision.NoDecision` plus residual policies (as Cedar JSON) otherwise; callers re-evaluate the residuals once the unknowns are bound. `PartialAuthzResult` uses the same `decision` / `correlation_id` / `diagnostics` / `metrics` structure as `AuthzResult`, with `may_be_determining`, `must_be_determining`, `nontrivial_residuals`, and `unknown_entities` added to diagnostics. Unlike `is_authorized`, an absent or `None` `context` is treated as unknown rather than empty. Pass `context={}` for an explicitly empty context. **Note: A partial-eval result is not a final authorization decision.** Re-run `is_authorized` once unknowns are bound; schema type-checking (including action-typed context shapes) is skipped while fields remain unknown. Enables the `partial-eval` Cargo feature on `cedar-policy` ([#28](https://github.com/k9securityio/cedar-py/issues/28)) — Thanks [@swenger](https://github.com/swenger)!
 
 ### Changed
 
@@ -67,7 +69,8 @@ Dependency update release. No functional or API changes — Cedar Policy engine 
 
 - Performance regression test suite built on `pytest-benchmark` ([#39](https://github.com/k9securityio/cedar-py/pull/39))
 
-[Unreleased]: https://github.com/k9securityio/cedar-py/compare/v4.8.3...HEAD
+[Unreleased]: https://github.com/k9securityio/cedar-py/compare/v4.8.4...HEAD
+[4.8.4]: https://github.com/k9securityio/cedar-py/compare/v4.8.3...v4.8.4
 [4.8.3]: https://github.com/k9securityio/cedar-py/compare/v4.8.2...v4.8.3
 [4.8.2]: https://github.com/k9securityio/cedar-py/compare/v4.8.1...v4.8.2
 [4.8.1]: https://github.com/k9securityio/cedar-py/compare/v4.8.0...v4.8.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "cedarpy"
-version = "4.8.3"
+version = "4.8.4"
 dependencies = [
  "anyhow",
  "cedar-policy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 # Maturin merges package metadata from pyproject.toml (preferred) and Cargo.toml
 # c.f. https://github.com/PyO3/maturin?tab=readme-ov-file#python-metadata
 name = "cedarpy"
-version = "4.8.3"
+version = "4.8.4"
 edition = "2021"
 readme = "README.md"
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <table>
 <thead><tr><th>Cedar Policy (engine) release</th><th>cedarpy release</th><th>cedarpy branch</th></tr></thead>
 <tbody>
-    <tr><td>v4.8.2</td><td>v4.8.3</td><td>main</td></tr>
+    <tr><td>v4.8.2</td><td>v4.8.4</td><td>main</td></tr>
     <tr><td>v4.7.2</td><td>v4.7.1</td><td>release/4.7.x</td></tr>
     <tr><td>v4.1.0</td><td>v4.1.0</td><td>release/4.1.x</td></tr>
     <tr><td>v2.2.0</td><td>v0.4.1</td><td>release/2.2.x</td></tr>


### PR DESCRIPTION
## Summary

First release including partial-evaluation support and the median-of-N benchmark gate. Cedar Policy engine version is unchanged (still v4.8.2).

### Added
- `is_authorized_partial` / `PartialAuthzResult` — Cedar partial-evaluation authorizer. Treats absent or `None` request fields as unknowns; returns `Allow`/`Deny` when unknowns cannot change the outcome, `NoDecision` plus residuals otherwise. Enables the `partial-eval` Cargo feature on `cedar-policy`. Thanks @swenger. (#28, #82)

### Changed
- `make benchmark-compare` runs N=5 release-mode benchmarks at HEAD and gates on median Δ vs baseline; prior mean threshold dropped. Per-run JSONs land in `tests/benchmark/results/current/`. (#69)

See [CHANGELOG.md](https://github.com/k9securityio/cedar-py/blob/release/4.8.4/CHANGELOG.md) for the full entry.

## Test plan

- [x] CI green across all platforms (linux x86_64/aarch64, macos x86_64/aarch64, windows x64)
- [ ] After merge: tag `v4.8.4`, approve `pypi-release` deployment
- [ ] Verify wheels + sdist + provenance on https://pypi.org/project/cedarpy/4.8.4/
- [ ] `gh release create v4.8.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
