### PR TITLE
fix(benchmark): use fixed-width short SHA in aggregate.py

### DIFF
--- a/tests/benchmark/aggregate.py
+++ b/tests/benchmark/aggregate.py
@@ -43,6 +43,14 @@ HISTORY_DIR = RESULTS_DIR / "history"
 HISTORY_MD = RESULTS_DIR / "HISTORY.md"
 MANIFEST_PATH = HISTORY_DIR / "states-manifest.json"
 
+# Fixed short-SHA length for history filenames and the `short_sha` field.
+# We truncate the full SHA ourselves rather than use git's `%h`, whose
+# auto-abbreviation length grows as the repo accumulates objects (7 -> 8 -> ...).
+# A growing `%h` re-derives a different filename/field for the same commit on
+# every re-aggregate, churning the committed record and emitting duplicate
+# <sha>.json files. A fixed width keeps re-aggregation a no-op.
+SHORT_SHA_LEN = 7
+
 
 def median_baseline_path(save_prefix: str) -> Path:
     """Default output path for build_baseline_from_state, per save_prefix."""
@@ -91,10 +99,13 @@ def commit_metadata(sha: str) -> dict:
     """
     info = git(
         "log", "-1",
-        "--pretty=format:%H%x1f%h%x1f%aI%x1f%s%x1f%b",
+        "--pretty=format:%H%x1f%aI%x1f%s%x1f%b",
         sha,
     ).split("\x1f")
-    long_sha, short_sha, iso_date, subject, body = info
+    long_sha, iso_date, subject, body = info
+    # Fixed-width abbreviation; do NOT use git's `%h` (its length grows with the
+    # repo, see SHORT_SHA_LEN).
+    short_sha = long_sha[:SHORT_SHA_LEN]
     # Author date as YYYY-MM-DD
     date = iso_date.split("T", 1)[0]
     # First non-empty line of the body (PR title for GitHub merges)


### PR DESCRIPTION
## Problem

`aggregate.py`'s `commit_metadata` derived `short_sha` from git's `%h`, whose abbreviation length grows as the repo accumulates objects (7 → 8 chars). Both the per-commit history filename (`filename_for`) and the `short_sha` JSON field depend on it, so re-running the aggregator re-derived a *different* name for the same commit. The result:

- duplicate `<sha>.json` summaries (one 7-char, one 8-char) for every untagged state, and
- duplicate rows in `HISTORY.md`.

This is the churn that had to be cleaned up by hand while capturing v4.8.5 (#93).

## Fix

Derive `short_sha` by truncating the full SHA to a fixed `SHORT_SHA_LEN` (7), matching the existing committed record. Re-aggregation now overwrites the same filenames instead of duplicating them.

## Verification

- All states (including tags) now yield stable **7-char** SHAs; filenames match the committed record (`500a8d0.json`, `6f601df.json`, …).
- A full `aggregate.py` run creates **zero duplicate files** and no longer changes `short_sha` on any existing summary.
- This PR touches **`aggregate.py` only** (no regenerated data files).

## Out of scope (flagged, not fixed here)

- **`captured_at` churn:** still stamped at aggregate time, so a re-aggregate rewrites that one timestamp line per file. Cosmetic, no duplication.
- **`v4.8.5.json` carries an 8-char `short_sha`** (committed in #93); the fixed tool will self-correct it to 7-char on its next capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
