### PR TITLE
chore: add CODEOWNERS for CI/CD trusted computing base

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,24 @@
+# Code owners for cedar-py.
+# https://docs.github.com/articles/about-code-owners
+#
+# Owners listed here are AUTO-REQUESTED for review on pull requests that
+# touch the matching paths. The goal is to protect the CI/CD trusted
+# computing base — the workflows that build, test, and publish the package,
+# and the automation policy around them — from unreviewed changes.
+#
+# NOTE: this file only auto-requests review. To make code-owner review a
+# *merge requirement*, enable "Require review from Code Owners" in the
+# branch protection rule / ruleset for `main` (a repo setting, not
+# expressible here). For a solo maintainer that toggle will block your own
+# PRs (you can't review your own), so leave it advisory until there's a
+# second reviewer; the auto-request is still valuable for outside-contributor PRs.
+
+# GitHub Actions workflows — build, test, and OIDC publish to PyPI.
+# SHA-pinned and zizmor-linted; changes here alter the trusted build/release path.
+/.github/workflows/       @skuenzli
+
+# Dependency + automation policy (Dependabot config).
+/.github/dependabot.yml   @skuenzli
+
+# This file itself — changing code ownership requires the owner's review.
+/.github/CODEOWNERS        @skuenzli


### PR DESCRIPTION
Follow-up to the #62 supply-chain hardening (out-of-band item #1).

Adds `.github/CODEOWNERS` to **auto-request maintainer review** on PRs touching the trusted CI/CD path:

| Path | Why |
|---|---|
| `/.github/workflows/` | the SHA-pinned, zizmor-linted workflows that build, test, and OIDC-publish to PyPI |
| `/.github/dependabot.yml` | dependency/automation policy |
| `/.github/CODEOWNERS` | changing ownership itself requires owner review |

### Owner choice
`@skuenzli` — no team (`build`, `product-eng`) has *direct* access to this repo, so a team owner would be flagged invalid by CODEOWNERS validation.

### Important: this file is advisory by itself
CODEOWNERS only **auto-requests** review. To make code-owner review a **merge requirement**, enable *"Require review from Code Owners"* in the branch protection rule / ruleset for `main` (a repo setting, not expressible in the file).

Caveat for a solo maintainer: that toggle would block your *own* PRs (you can't approve your own), so it's left **off** for now — the auto-request is still valuable for outside-contributor PRs (e.g. recent template/dep PRs). Revisit if a second reviewer joins.

CI: this is a docs/config-only change; the build matrix + zizmor lint run as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
