### PR TITLE
release: bump version to 4.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [4.8.6] - 2026-06-27
+
 ### Added
 
 - Cedar **policy template** linking on the `PolicySet` handle. `PolicySet.from_str` already parses templates (policies with `?principal` / `?resource` slots); they authorize nothing until linked. `policy_set.with_linked_batch(links)` links one or more templates and returns a **new** `PolicySet` handle (the base is cloned once and left unchanged, mirroring `with_added_str`), so a batch of links pays a single clone rather than one per link; it is all-or-nothing (any failure raises and no handle is returned). `with_linked(template_id, new_id, values)` is the single-link convenience over it. Each slot value is a Cedar string (`'User::"jane"'`) or a `{"type": ..., "id": ...}` dict — the two forms a request principal/resource already accept. A `template_id` resolves to a template's literal Cedar id first, then to the value of its `@id` annotation — but prefer the `@id`, since it is the stable key: the positional id (`policy0`, …) is reassigned per parse and renumbered by `with_added_str`, while the `@id` is invariant (the `@id` match must be unambiguous; `@id` is otherwise inert and is not the template's id — matching the Cedar CLI's linking convention). A linked `PolicySet` is still just a `PolicySet`, evaluating through `is_authorized`, `is_authorized_batch`, and `is_authorized_partial`; existing callers are untouched, so this is a pure, opt-in addition. The lifecycle is rounded out by `templates()` (a list of dicts, one per template, with its `id`, `id_annotation`, `slots`, and the `links` derived from it — each link's `id` and the `values` its slots were bound to) and `without_linked(link_id)` (a new handle with one linked policy removed). Regular template linking works on the pinned engine — no new Cargo feature ([#29](https://github.com/k9securityio/cedar-py/issues/29)). Thanks [@Iamrodos](https://github.com/Iamrodos)!
 - A reusable, pre-parsed `Entities` handle, mirroring the `PolicySet` handle. Parse a stable entity graph once with `Entities.from_json_str(entities_json, schema=None)` and pass the handle to `is_authorized`, `is_authorized_batch`, or `is_authorized_partial` anywhere an entities string/list is accepted — skipping the per-call JSON deserialization and transitive-closure computation. For the common "stable base plus a small per-request delta" pattern, `entities.with_added_json_str(delta_json, schema=None)` clones the base and parses only the delta, returning a **new** handle (the base is immutable and reused). The merge is a disjoint union: a delta uid that duplicates a non-identical base uid raises `ValueError`, as does malformed JSON or a schema violation. The `entities` parameter widens from `str | list` to `str | list | Entities`; existing string/list callers are unchanged, so this is a pure, opt-in addition. The handle supports `len()` (entity count) and `str()` (rendered entities JSON), and on a successful evaluation the result `metrics` gain an `entities_pre_parsed` flag (`1` for the handle path, `0` otherwise). Mirrors the cedar-java / cedar-policy-rb handle APIs ([#83](https://github.com/k9securityio/cedar-py/issues/83)). Thanks [@Iamrodos](https://github.com/Iamrodos)!
 - `PolicySet.with_added_str(fragment)` returns a **new** `PolicySet` handle: the compiled base plus the policies parsed from `fragment`. The base is cloned, not re-parsed — only the (typically small) fragment is parsed — so a caller with a static base and small dynamic per-request fragments avoids re-parsing the base each call. The result is equivalent to authorizing against the concatenated base-plus-fragment text: because Cedar derives a positional `PolicyId` (`policy0`, `policy1`, …) per parse, the fragment's colliding ids are renumbered to follow the base (as concatenation would), and `@id` annotations are preserved. Raises `ValueError` on an unparseable fragment ([#83](https://github.com/k9securityio/cedar-py/issues/83)).
+
+### Security
+
+- **CI/release supply-chain hardening.** Every GitHub Action in the build and release workflow is now pinned to a full commit SHA (with the human-readable version tag in a trailing comment), and `actions/checkout` runs with `persist-credentials: false`. A `zizmor` workflow-lint job and a repository action-allowlist that requires SHA-pinned actions enforce this on every change. Build provenance now produces a **single combined attestation** referencing all wheels (`actions/attest-build-provenance@v4`) instead of one attestation per wheel — relevant to anyone verifying SLSA provenance on the distributions. No change to the published package's code or behavior ([#62](https://github.com/k9securityio/cedar-py/issues/62)).
 
 ## [4.8.5] - 2026-06-21
 
@@ -87,7 +93,8 @@ Dependency update release. No functional or API changes — Cedar Policy engine 
 
 - Performance regression test suite built on `pytest-benchmark` ([#39](https://github.com/k9securityio/cedar-py/pull/39))
 
-[Unreleased]: https://github.com/k9securityio/cedar-py/compare/v4.8.5...HEAD
+[Unreleased]: https://github.com/k9securityio/cedar-py/compare/v4.8.6...HEAD
+[4.8.6]: https://github.com/k9securityio/cedar-py/compare/v4.8.5...v4.8.6
 [4.8.5]: https://github.com/k9securityio/cedar-py/compare/v4.8.4...v4.8.5
 [4.8.4]: https://github.com/k9securityio/cedar-py/compare/v4.8.3...v4.8.4
 [4.8.3]: https://github.com/k9securityio/cedar-py/compare/v4.8.2...v4.8.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "cedarpy"
-version = "4.8.5"
+version = "4.8.6"
 dependencies = [
  "anyhow",
  "cedar-policy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 # Maturin merges package metadata from pyproject.toml (preferred) and Cargo.toml
 # c.f. https://github.com/PyO3/maturin?tab=readme-ov-file#python-metadata
 name = "cedarpy"
-version = "4.8.5"
+version = "4.8.6"
 edition = "2021"
 readme = "README.md"
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <table>
 <thead><tr><th>Cedar Policy (engine) release</th><th>cedarpy release</th><th>cedarpy branch</th></tr></thead>
 <tbody>
-    <tr><td>v4.8.2</td><td>v4.8.5</td><td>main</td></tr>
+    <tr><td>v4.8.2</td><td>v4.8.6</td><td>main</td></tr>
     <tr><td>v4.7.2</td><td>v4.7.1</td><td>release/4.7.x</td></tr>
     <tr><td>v4.1.0</td><td>v4.1.0</td><td>release/4.1.x</td></tr>
     <tr><td>v2.2.0</td><td>v0.4.1</td><td>release/2.2.x</td></tr>


### PR DESCRIPTION
Release PR for **cedarpy v4.8.6**. Cedar Policy engine unchanged (v4.8.2).

Bumps `Cargo.toml`, `Cargo.lock`, the README compatibility table, and promotes the `CHANGELOG.md` `[Unreleased]` section.

### Added
- **Cedar policy template linking** on the `PolicySet` handle — `with_linked` / `with_linked_batch` / `without_linked` / `templates()` ([#29](https://github.com/k9securityio/cedar-py/issues/29), thanks @Iamrodos)
- **Reusable, pre-parsed `Entities` handle** + `with_added_json_str` ([#83](https://github.com/k9securityio/cedar-py/issues/83), thanks @Iamrodos)
- **`PolicySet.with_added_str`** — extend a compiled base without re-parsing ([#83](https://github.com/k9securityio/cedar-py/issues/83))

### Security
- **CI/release supply-chain hardening** ([#62](https://github.com/k9securityio/cedar-py/issues/62)): all actions SHA-pinned with tag comments, `checkout` `persist-credentials: false`, zizmor lint gate, repo action-allowlist requiring SHA pins. Build provenance is now a single combined attestation over all wheels (`attest-build-provenance@v4`) instead of one per wheel. No change to the package's code or behavior.

### Notes
- This is the **first release through the #62-hardened pipeline**, so it also serves as the live validation of the upgraded `release` job (`download-artifact@v8`, `attest-build-provenance@v4`, `maturin upload`) — those run only on the tag push after merge.
- Merge gate: green CI across all platforms + the zizmor lint job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
