### PR TITLE
release: bump version to 4.8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [4.8.7] - 2026-07-10
+
 ### Added
 
 - A reusable, pre-parsed `Schema` handle, completing the handle trio alongside `PolicySet` and `Entities`. Parse a schema once with `Schema.from_str(cedar_text)` or `Schema.from_json_str(json_text)` and pass the handle to `is_authorized`, `is_authorized_batch`, `is_authorized_partial`, or `validate_policies` anywhere a schema string is accepted — skipping the per-call parse. The `schema` parameter widens from `str | dict | None` to `str | dict | Schema | None`; existing string/dict callers are unchanged, so this is a pure, opt-in addition. The handle is immutable, releases its memory when the last Python reference is dropped, supports `str()` (the schema rendered to Cedar schema syntax, whichever format it was constructed from), and raises `ValueError` at construction on unparseable schemas. On a successful evaluation the result `metrics` gain a `schema_pre_parsed` flag (`1` for the handle path, `0` otherwise). Mirrors the `PolicySet` / `Entities` handle APIs ([#103](https://github.com/k9securityio/cedar-py/pull/103)). Thanks [@swenger](https://github.com/swenger)!
@@ -97,7 +99,8 @@ Dependency update release. No functional or API changes — Cedar Policy engine 
 
 - Performance regression test suite built on `pytest-benchmark` ([#39](https://github.com/k9securityio/cedar-py/pull/39))
 
-[Unreleased]: https://github.com/k9securityio/cedar-py/compare/v4.8.6...HEAD
+[Unreleased]: https://github.com/k9securityio/cedar-py/compare/v4.8.7...HEAD
+[4.8.7]: https://github.com/k9securityio/cedar-py/compare/v4.8.6...v4.8.7
 [4.8.6]: https://github.com/k9securityio/cedar-py/compare/v4.8.5...v4.8.6
 [4.8.5]: https://github.com/k9securityio/cedar-py/compare/v4.8.4...v4.8.5
 [4.8.4]: https://github.com/k9securityio/cedar-py/compare/v4.8.3...v4.8.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "cedarpy"
-version = "4.8.6"
+version = "4.8.7"
 dependencies = [
  "anyhow",
  "cedar-policy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 # Maturin merges package metadata from pyproject.toml (preferred) and Cargo.toml
 # c.f. https://github.com/PyO3/maturin?tab=readme-ov-file#python-metadata
 name = "cedarpy"
-version = "4.8.6"
+version = "4.8.7"
 edition = "2021"
 readme = "README.md"
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <table>
 <thead><tr><th>Cedar Policy (engine) release</th><th>cedarpy release</th><th>cedarpy branch</th></tr></thead>
 <tbody>
-    <tr><td>v4.8.2</td><td>v4.8.6</td><td>main</td></tr>
+    <tr><td>v4.8.2</td><td>v4.8.7</td><td>main</td></tr>
     <tr><td>v4.7.2</td><td>v4.7.1</td><td>release/4.7.x</td></tr>
     <tr><td>v4.1.0</td><td>v4.1.0</td><td>release/4.1.x</td></tr>
     <tr><td>v2.2.0</td><td>v0.4.1</td><td>release/2.2.x</td></tr>


### PR DESCRIPTION
Release PR for cedarpy v4.8.7, per [docs/release-process.md](docs/release-process.md).

## Changes since v4.8.6

- A reusable, pre-parsed `Schema` handle, completing the handle trio alongside `PolicySet` and `Entities` (#103). Parse a schema once with `Schema.from_str` / `Schema.from_json_str` and pass the handle anywhere a schema string is accepted, skipping the per-call schema parse. Purely opt-in: string/dict callers are unchanged. The handle supports `str()` (rendered Cedar schema syntax), reports entity-type/action counts in `repr()`, and sets a `schema_pre_parsed` metrics flag. Thanks @swenger!

No Cedar engine version change (still 4.8.2).

## Version-bump files

- `Cargo.toml` → 4.8.7
- `Cargo.lock` regenerated via `cargo build` (version line only)
- README compatibility table cedarpy cell → v4.8.7
- `CHANGELOG.md`: `[Unreleased]` promoted to `[4.8.7] - 2026-07-10`, fresh empty `[Unreleased]` added, comparison links updated

All 218 unit tests pass locally on the release build.