### PR TITLE
chore: update declared Rust deps to latest patch versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Security
+
+- Updated `anyhow` 1.0.95 → 1.0.104, clearing the [RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190) unsoundness warning in `Error::downcast_mut` (fixed upstream in 1.0.103).
+
 ### Changed
+
+- Updated the remaining declared Rust dependencies to their latest patch releases: `pyo3` 0.27.1 → 0.27.2 (crash fix for Rust 1.92+ builds with debug assertions; no API changes), `serde` 1.0.228 → 1.0.229, and `serde_json` 1.0.145 → 1.0.151 (float formatting switched from Ryū to Żmij upstream — output can differ textually while remaining valid; the 60,800-case Cedar corpus passes unchanged). No behavior changes observed across unit, integration, corpus, or benchmark suites.
 
 - Removed the unused `cedar-policy-cli` crate dependency, present since the project's initial scaffold but never referenced from code. Drops 34 transitive crates (`clap`, `miette`'s terminal-support stack, `rustix`, …) from `Cargo.lock`, shrinking build time, audit surface, and the version-resolution coupling its exact `=X.Y.Z` pin on `cedar-policy` imposed. No functional change — `cedar-policy-formatter` (which backs `format_policies`) remains.
 - **Cedar Policy engine upgraded from v4.8.2 to [v4.12.0](https://github.com/cedar-policy/cedar/releases/tag/v4.12.0)** (Cedar language version 4.4 → 4.5, adding the extended `has` operator in JSON policies). No `cedarpy` API changes: the engine's breaking changes between 4.9 and 4.12 are confined to experimental features `cedarpy` does not enable (`pst`, `tpe`, `protobuf`, `tolerant-ast`), and the `partial-eval` surface is unchanged. Verified against the upstream v4.12.0 integration corpus (60,800 request cases), including the new JSON-policy-format and JSON-schema-format suites ([#106](https://github.com/k9securityio/cedar-py/pull/106)). Thanks [@h0rv](https://github.com/h0rv)!

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arrayvec"
@@ -823,9 +823,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a6df7eab65fc7bee654a421404947e10a0f7085b6951bf2ea395f4659fb0cf"
+checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
 dependencies = [
  "indoc",
  "libc",
@@ -840,18 +840,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f77d387774f6f6eec64a004eac0ed525aab7fa1966d94b42f743797b3e395afb"
+checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dd13844a4242793e02df3e2ec093f540d948299a6a77ea9ce7afd8623f542be"
+checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -859,9 +859,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf8f9f1108270b90d3676b8679586385430e5c0bb78bb5f043f95499c821a71"
+checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -871,9 +871,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a3b2274450ba5288bc9b8c1b69ff569d1d61189d4bff38f8d22e03d17f932b"
+checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -962,12 +962,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
-name = "ryu"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,9 +1008,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1024,36 +1018,36 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "indexmap 2.7.0",
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1504,3 +1498,9 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"


### PR DESCRIPTION
Updates every declared Rust dependency to its latest patch release, staying within existing `Cargo.toml` caret ranges (no manifest change). All versions are past the 7-day cooldown.

| Crate | From | To | Published |
|---|---|---|---|
| pyo3 (+4 companions) | 0.27.1 | 0.27.2 | 2025-11-30 |
| anyhow | 1.0.95 | 1.0.104 | 2026-07-18 |
| serde (+core/derive) | 1.0.228 | 1.0.229 | 2026-07-18 |
| serde_json | 1.0.145 | 1.0.151 | 2026-07-20 |
| cedar-policy / -formatter | 4.12.0 | (already newest 4.12.x) | — |

**Security:** anyhow 1.0.103 fixed the `Error::downcast_mut` unsoundness — [RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190) no longer appears in `cargo audit`.

**Changelog review:** pyo3 0.27.2 is two bug fixes (Rust 1.92+ crash, GraalPy FFI), no API changes. serde 1.0.229 is internal (derive moved to syn 3, already in-tree). serde_json 1.0.147 switched float formatting (Ryū → Żmij) and 1.0.150 rejects non-string enum object keys — neither pattern applies to cedarpy's serialization paths, and the corpus passes unchanged.

## Verification

| Check | Result |
|---|---|
| unit | 218 passed |
| integration | 78 passed |
| corpus | 60,800 passed |
| benchmark gate (N=5 vs 4.12 baseline) | PASS — all 35 benchmarks within −3.0%…+0.5% |
| cargo audit | anyhow warning cleared, no new findings |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
